### PR TITLE
Batch export sky as individual skyboxes and rotating elements

### DIFF
--- a/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
@@ -630,28 +630,47 @@ namespace LanternExtractor.EQ.Wld.Exporters
                     skySkeletonMeshNames.Add(b.MeshReference.Mesh.Name);
                 }
             }));
-
             var skyMeshes = skyWld.GetFragmentsOfType<Mesh>().Where(m => !skySkeletonMeshNames.Contains(m.Name));
-
             var materialLists = GatherMaterialLists(skySkeletons.Cast<WldFragment>().Concat(skyMeshes.Cast<WldFragment>()).ToList());
 
             var exportFormat = settings.ExportGltfInGlbFormat ? GltfExportFormat.Glb : GltfExportFormat.GlTF;
-            var gltfWriter = new GltfWriter(settings.ExportGltfVertexColors, exportFormat, logger, settings.SeparateTwoFacedTriangles);
 
             var exportFolder = skyWld.GetExportFolderForWldType();
-
             var textureImageFolder = $"{exportFolder}Textures/";
-            gltfWriter.GenerateGltfMaterials(materialLists, textureImageFolder);
 
-            foreach (var mesh in skyMeshes)
+
+            for (int i = 1; ; i++)
             {
-                gltfWriter.AddFragmentData(
-                    mesh: mesh,
-                    generationMode: ModelGenerationMode.Separate);
+                List<Mesh> meshes = new List<Mesh>();
+                foreach (var mesh in skyMeshes)
+                {
+                    if (new System.Text.RegularExpressions.Regex($"LAYER{i}[13]_").IsMatch(mesh.Name))
+                    {
+                        meshes.Add(mesh);
+                    }
+                }
+                if (meshes.Count == 0)
+                {
+                    break;
+                }
+                var gltfWriter = new GltfWriter(settings.ExportGltfVertexColors, exportFormat, logger, settings.SeparateTwoFacedTriangles);
+                gltfWriter.GenerateGltfMaterials(materialLists, textureImageFolder);
+                foreach (var mesh in meshes)
+                {
+                    gltfWriter.AddFragmentData(
+                        mesh: mesh,
+                        generationMode: ModelGenerationMode.Separate);
+                }
+
+                var exportFilePath = $"{exportFolder}sky{i}.gltf";
+                gltfWriter.WriteAssetToFile(exportFilePath, true);
             }
+
 
             foreach (var skeleton in skySkeletons)
             {
+                var gltfWriter = new GltfWriter(settings.ExportGltfVertexColors, exportFormat, logger, settings.SeparateTwoFacedTriangles);
+                gltfWriter.GenerateGltfMaterials(materialLists, textureImageFolder);
                 var combinedMeshName = FragmentNameCleaner.CleanName(skeleton);
                 for (int i = 0; i < skeleton.Skeleton.Count; i++)
                 {
@@ -670,18 +689,17 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
                 gltfWriter.AddCombinedMeshToScene(true, combinedMeshName, skeleton.ModelBase);
 
-				if (settings.ExportAllAnimationFrames)
-				{
-					gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", false, true);
-					foreach (var animationKey in skeleton.Animations.Keys)
-					{
-						gltfWriter.ApplyAnimationToSkeleton(skeleton, animationKey, false, false);
-					}
-				}
-			}
-
-            var exportFilePath = $"{exportFolder}sky.gltf";
-            gltfWriter.WriteAssetToFile(exportFilePath, true);
+                if (settings.ExportAllAnimationFrames)
+                {
+                    gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", false, true);
+                    foreach (var animationKey in skeleton.Animations.Keys)
+                    {
+                        gltfWriter.ApplyAnimationToSkeleton(skeleton, animationKey, false, false);
+                    }
+                }
+                var exportFilePath = $"{exportFolder}{skeleton.ModelBase}.gltf";
+                gltfWriter.WriteAssetToFile(exportFilePath, true);
+            }
         }
 
         private static string GetUniqueNpcString(string actorName, Npc npc)


### PR DESCRIPTION
This allows the export of individual skyboxes and animated elements rather than combining them into one scene.

Should this maybe be a setting? I wasn't sure if this was supported somewhere else to combine all of the meshes and use them