### PR TITLE
Export regions in gltf

### DIFF
--- a/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
@@ -172,8 +172,17 @@ namespace LanternExtractor.EQ.Wld.Exporters
             var textureImageFolder = $"{wldFileZone.GetExportFolderForWldType()}Textures/";
             gltfWriter.GenerateGltfMaterials(materialLists, textureImageFolder);
 
+            var bspNodes = wldFileZone.GetFragmentsOfType<BspTree>();
             foreach (var mesh in zoneMeshes)
             {
+                if (settings.ExportZoneMeshGroups)
+                {
+                    var frag = bspNodes[0].Nodes.Find(n => n.Region?.Mesh == mesh);
+                    if (frag?.Region?.RegionType != null)
+                    {
+                        gltfWriter.AddRegionData(mesh, frag);
+                    }
+                }
                 gltfWriter.AddFragmentData(
                     mesh: mesh,
                     generationMode: ModelGenerationMode.Combine,

--- a/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
@@ -175,7 +175,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
             var bspNodes = wldFileZone.GetFragmentsOfType<BspTree>();
             foreach (var mesh in zoneMeshes)
             {
-                if (settings.ExportZoneMeshGroups)
+                if (settings.ExportZoneRegions)
                 {
                     var frag = bspNodes[0].Nodes.Find(n => n.Region?.Mesh == mesh);
                     if (frag?.Region?.RegionType != null)

--- a/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
@@ -12,7 +12,8 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Numerics;
-
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using WldColor = LanternExtractor.EQ.Wld.DataTypes.Color;
 using Animation = LanternExtractor.EQ.Wld.DataTypes.Animation;
 using System.Drawing.Imaging;
@@ -289,6 +290,37 @@ namespace LanternExtractor.EQ.Wld.Exporters
                     }
                 }
             }
+        }
+
+        public void AddRegionData(Mesh mesh, DataTypes.BspNode frag)
+        {
+            var meshBuilder = new MeshBuilder<VertexPositionNormal>(mesh.Name);
+            var materialBuilder = new MaterialBuilder("");
+            var meshHelper = new WldMeshHelper(mesh, _separateTwoFacedTriangles);
+            var polygonCount = mesh.MaterialGroups.Aggregate(0, (acc, val) => acc + val.PolygonCount);
+
+            for (var i = 0; i < polygonCount; i++)
+            {
+                var triangle = meshHelper.GetTriangle(i);
+                var vertexPositions = meshHelper.GetVertexPositions(triangle);
+                var prim = meshBuilder.UsePrimitive(materialBuilder);
+
+                prim.AddTriangle(
+                    new VertexBuilder<VertexPosition, VertexEmpty, VertexEmpty>(new VertexPosition(vertexPositions.v2)),
+                    new VertexBuilder<VertexPosition, VertexEmpty, VertexEmpty>(new VertexPosition(vertexPositions.v1)),
+                    new VertexBuilder<VertexPosition, VertexEmpty, VertexEmpty>(new VertexPosition(vertexPositions.v0))
+                    );
+            }
+
+            var regionMetadata = new System.Dynamic.ExpandoObject() as IDictionary<string, object>;
+            regionMetadata.Add("regions", frag?.Region?.RegionType?.RegionTypes ?? new List<DataTypes.RegionType>());
+
+            if (frag?.Region?.RegionType?.Zoneline != null)
+            {
+                regionMetadata.Add("zoneLine", frag.Region.RegionType.Zoneline);
+            }
+            meshBuilder.Extras = SharpGLTF.IO.JsonContent.Parse(JsonSerializer.Serialize(regionMetadata));
+            _scene.AddRigidMesh(meshBuilder, new AffineTransform(Matrix4x4.Identity));
         }
 
         public void AddFragmentData(
@@ -605,6 +637,17 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
 			var outputFilePath = FixFilePath(fileName);
             var model = _scene.ToGltf2();
+
+            foreach (var node in model.LogicalNodes)
+            {
+                if (node.Mesh != null && (node.Mesh.Extras.Content?.ToString() ?? string.Empty) != string.Empty)
+                {
+                    node.Extras = node.Mesh.Extras;
+                    JsonNode regionTypes = JsonSerializer.Deserialize<JsonNode>(node.Extras.ToJson())["regions"];
+                    var reg = regionTypes.AsArray().Select(a => a.GetValue<int>().ToString());
+                    node.Name = $"region_{string.Join("-", reg)}";
+                }
+            }
 
             if (_exportFormat == GltfExportFormat.GlTF)
             {

--- a/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
@@ -297,7 +297,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
             var meshBuilder = new MeshBuilder<VertexPositionNormal>(mesh.Name);
             var materialBuilder = new MaterialBuilder("");
             var meshHelper = new WldMeshHelper(mesh, _separateTwoFacedTriangles);
-            var polygonCount = mesh.MaterialGroups.Aggregate(0, (acc, val) => acc + val.PolygonCount);
+            var polygonCount = mesh.MaterialGroups.Sum(material => material.PolygonCount);
 
             for (var i = 0; i < polygonCount; i++)
             {
@@ -306,9 +306,9 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 var prim = meshBuilder.UsePrimitive(materialBuilder);
 
                 prim.AddTriangle(
-                    new VertexBuilder<VertexPosition, VertexEmpty, VertexEmpty>(new VertexPosition(vertexPositions.v2)),
-                    new VertexBuilder<VertexPosition, VertexEmpty, VertexEmpty>(new VertexPosition(vertexPositions.v1)),
-                    new VertexBuilder<VertexPosition, VertexEmpty, VertexEmpty>(new VertexPosition(vertexPositions.v0))
+                    new VertexBuilder<VertexPosition, VertexEmpty, VertexEmpty>(new VertexPosition(Vector3.Transform(vertexPositions.v2, Matrix4x4.CreateScale(ZoneScaleMultiplier)))),
+                    new VertexBuilder<VertexPosition, VertexEmpty, VertexEmpty>(new VertexPosition(Vector3.Transform(vertexPositions.v1, Matrix4x4.CreateScale(ZoneScaleMultiplier)))),
+                    new VertexBuilder<VertexPosition, VertexEmpty, VertexEmpty>(new VertexPosition(Vector3.Transform(vertexPositions.v0, Matrix4x4.CreateScale(ZoneScaleMultiplier))))
                     );
             }
 

--- a/LanternExtractor/Settings.cs
+++ b/LanternExtractor/Settings.cs
@@ -49,6 +49,11 @@ namespace LanternExtractor
         public bool ExportZoneMeshGroups { get; private set; }
 
         /// <summary>
+        /// Adds zone regions to the gltf scene
+        /// </summary>
+        public bool ExportZoneRegions { get; private set; }
+
+        /// <summary>
         /// Exports hidden geometry like zone boundaries
         /// </summary>
         public bool ExportHiddenGeometry { get; private set; }
@@ -161,6 +166,7 @@ namespace LanternExtractor
             EverQuestDirectory = "C:/EverQuest/";
             RawS3dExtract = false;
             ExportZoneMeshGroups = false;
+            ExportZoneRegions = false;
             ExportHiddenGeometry = false;
             LoggerVerbosity = 0;
         }
@@ -203,6 +209,11 @@ namespace LanternExtractor
             if (parsedSettings.ContainsKey("ExportZoneMeshGroups"))
             {
                 ExportZoneMeshGroups = Convert.ToBoolean(parsedSettings["ExportZoneMeshGroups"]);
+            }
+
+            if (parsedSettings.ContainsKey("ExportZoneRegions"))
+            {
+                ExportZoneRegions = Convert.ToBoolean(parsedSettings["ExportZoneRegions"]);
             }
 
             if (parsedSettings.ContainsKey("ExportHiddenGeometry"))

--- a/LanternExtractor/settings.txt
+++ b/LanternExtractor/settings.txt
@@ -26,6 +26,10 @@ ModelExportFormat = 2
 # (Intermediate, OBJ)
 ExportZoneMeshGroups = false
 
+# glTF will export empty meshes with metadata of the region information
+# (glTF)
+ExportZoneRegions = false
+
 # Include hidden geometry (invisible boundaries) in the zone collision export?
 # (Intermediate, OBJ)
 ExportHiddenGeometry = false


### PR DESCRIPTION
This exports region data with the associated meshes if the flag is set to true. Metadata includes the region types and zoneline information for the consumer.