### PR TITLE
Vertex/normal/polygon translation for gltf export

### DIFF
--- a/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
@@ -217,7 +217,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
                     var addedMeshOnce = false;
 
                     foreach (var instance in instances)
-                    {>>
+                    {
                         if (instance.Position.Y < ObjInstanceYAxisThreshold) continue;
 
                         if (!addedMeshOnce ||
@@ -699,16 +699,9 @@ namespace LanternExtractor.EQ.Wld.Exporters
                         gltfWriter.ApplyAnimationToSkeleton(skeleton, animationKey, false, false);
                     }
                 }
-<<<<<<< HEAD
-            }
-
-            var exportFilePath = $"{exportFolder}sky.gltf";
-            gltfWriter.WriteAssetToFile(exportFilePath, true);
-=======
                 var exportFilePath = $"{exportFolder}{skeleton.ModelBase}.gltf";
                 gltfWriter.WriteAssetToFile(exportFilePath, true);
             }
->>>>>>> master
         }
 
         private static string GetUniqueNpcString(string actorName, Npc npc)

--- a/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/ActorGltfExporter.cs
@@ -14,9 +14,9 @@ namespace LanternExtractor.EQ.Wld.Exporters
 {
     public static class ActorGltfExporter
     {
-        private const float ObjInstanceYAxisThreshold = -1000f;
+		private const float ObjInstanceYAxisThreshold = -1000f;
 
-        public static void ExportActors(WldFile wldFile, Settings settings, ILogger logger)
+		public static void ExportActors(WldFile wldFile, Settings settings, ILogger logger)
         {
             // For a zone wld, we ignore actors and just export all meshes
             if (wldFile.WldType == WldType.Zone)
@@ -97,8 +97,8 @@ namespace LanternExtractor.EQ.Wld.Exporters
             var objects = new List<ObjInstance>();
             var shortName = wldFileZone.ShortName;
             var exportFormat = settings.ExportGltfInGlbFormat ? GltfExportFormat.Glb : GltfExportFormat.GlTF;
-            var rootFolder = wldFileZone.RootFolder;
-            if (settings.ExportZoneWithObjects || settings.ExportZoneWithDoors)
+			var rootFolder = wldFileZone.RootFolder;
+			if (settings.ExportZoneWithObjects || settings.ExportZoneWithDoors)
             {
                 // Get object instances within this zone file to map up and instantiate later
                 var zoneObjectsFileInArchive =
@@ -141,32 +141,32 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 }
             }
 
-            var lightInstances = new List<LightInstance>();
-            if (settings.ExportZoneWithLights)
+			var lightInstances = new List<LightInstance>();
+			if (settings.ExportZoneWithLights)
             {
-                if (wldFileZone.WldFileToInject != null) // optional kunark _lit wld exists
-                {
-                    var kunarkLitPath = wldFileZone.BasePath.Replace(".s3d", "_lit.s3d");
-                    var s3dArchiveLit = new PfsArchive(kunarkLitPath, logger);
+				if (wldFileZone.WldFileToInject != null) // optional kunark _lit wld exists
+				{
+					var kunarkLitPath = wldFileZone.BasePath.Replace(".s3d", "_lit.s3d");
+				    var s3dArchiveLit = new PfsArchive(kunarkLitPath, logger);
                     s3dArchiveLit.Initialize();
                     var litWldFileInArchive = s3dArchiveLit.GetFile(shortName + "_lit.wld");
 
-                    var lightsWldFile =
-                        new WldFileLights(litWldFileInArchive, shortName, WldType.Lights, logger, settings, wldFileZone.WldFileToInject);
-                    lightsWldFile.Initialize(rootFolder, false);
+					var lightsWldFile =
+						new WldFileLights(litWldFileInArchive, shortName, WldType.Lights, logger, settings, wldFileZone.WldFileToInject);
+					lightsWldFile.Initialize(rootFolder, false);
                     lightInstances.AddRange(lightsWldFile.GetFragmentsOfType<LightInstance>());
-                }
+				}
 
-                var lightsFileInArchive = wldFileZone.S3dArchiveReference.GetFile("lights" + LanternStrings.WldFormatExtension);
+				var lightsFileInArchive = wldFileZone.S3dArchiveReference.GetFile("lights" + LanternStrings.WldFormatExtension);
 
-                if (lightsFileInArchive != null)
-                {
-                    var lightsWldFile =
-                        new WldFileLights(lightsFileInArchive, shortName, WldType.Lights, logger, settings, wldFileZone.WldFileToInject);
-                    lightsWldFile.Initialize(rootFolder, false);
+				if (lightsFileInArchive != null)
+				{
+					var lightsWldFile =
+						new WldFileLights(lightsFileInArchive, shortName, WldType.Lights, logger, settings, wldFileZone.WldFileToInject);
+					lightsWldFile.Initialize(rootFolder, false);
                     lightInstances.AddRange(lightsWldFile.GetFragmentsOfType<LightInstance>());
-                }
-            }
+				}
+			}
 
             var gltfWriter = new GltfWriter(settings, exportFormat, logger);
             var textureImageFolder = $"{wldFileZone.GetExportFolderForWldType()}Textures/";
@@ -227,9 +227,9 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
                     foreach (var instance in instances)
                     {
-                        if (instance.Position.Y < ObjInstanceYAxisThreshold) continue;
+						if (instance.Position.Y < ObjInstanceYAxisThreshold) continue;
 
-                        if (!addedMeshOnce ||
+						if (!addedMeshOnce ||
                             (settings.ExportGltfVertexColors
                              && instance.Colors?.Colors != null
                              && instance.Colors.Colors.Any()))
@@ -254,19 +254,19 @@ namespace LanternExtractor.EQ.Wld.Exporters
                                     mesh.Vertices = originalVertices;
                                 }
                             }
-                        }
+						}
 
                         if (settings.ExportZoneObjectsWithSkeletalAnimations)
                         {
                             gltfWriter.AddNewSkeleton(skeleton, null, null, instance, instanceIndex);
                             gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", false, true, instanceIndex);
-                            gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", false, false, instanceIndex);
-                            gltfWriter.AddCombinedMeshToScene(true, combinedMeshName, skeleton.ModelBase, instance, instanceIndex);
-                        }
+							gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", false, false, instanceIndex);
+							gltfWriter.AddCombinedMeshToScene(true, combinedMeshName, skeleton.ModelBase, instance, instanceIndex);
+						}
                         else
                         {
-                            gltfWriter.AddCombinedMeshToScene(true, combinedMeshName, null, instance);
-                        }
+							gltfWriter.AddCombinedMeshToScene(true, combinedMeshName, null, instance);
+						}  
                         addedMeshOnce = true;
                         instanceIndex++;
                     }
@@ -301,78 +301,78 @@ namespace LanternExtractor.EQ.Wld.Exporters
             gltfWriter.WriteAssetToFile(exportFilePath, true);
         }
 
-        private static void ExportSkeletalActor(Actor actor, Settings settings, WldFile wldFile, ILogger logger)
-        {
-            var skeleton = actor?.SkeletonReference?.SkeletonHierarchy;
+		private static void ExportSkeletalActor(Actor actor, Settings settings, WldFile wldFile, ILogger logger)
+		{
+			var skeleton = actor?.SkeletonReference?.SkeletonHierarchy;
 
-            if (skeleton == null) return;
+			if (skeleton == null) return;
 
-            if (settings.ExportAllAnimationFrames && wldFile.ZoneShortname != "global")
-            {
-                GlobalReference.CharacterWld.AddAdditionalAnimationsToSkeleton(skeleton);
-            }
+			if (settings.ExportAllAnimationFrames && wldFile.ZoneShortname != "global")
+			{
+				GlobalReference.CharacterWld.AddAdditionalAnimationsToSkeleton(skeleton);
+			}
 
-            var exportFormat = settings.ExportGltfInGlbFormat ? GltfExportFormat.Glb : GltfExportFormat.GlTF;
-            var gltfWriter = new GltfWriter(settings, exportFormat, logger);
+			var exportFormat = settings.ExportGltfInGlbFormat ? GltfExportFormat.Glb : GltfExportFormat.GlTF;
+			var gltfWriter = new GltfWriter(settings, exportFormat, logger);
 
-            var materialLists = GatherMaterialLists(new List<WldFragment>() { skeleton });
-            var exportFolder = wldFile.GetExportFolderForWldType();
+			var materialLists = GatherMaterialLists(new List<WldFragment>() { skeleton });
+			var exportFolder = wldFile.GetExportFolderForWldType();
 
             var textureImageFolder = Path.Combine(exportFolder, "Textures");
-            gltfWriter.GenerateGltfMaterials(materialLists, textureImageFolder);
+			gltfWriter.GenerateGltfMaterials(materialLists, textureImageFolder);
 
-            for (int i = 0; i < skeleton.Skeleton.Count; i++)
-            {
-                var bone = skeleton.Skeleton[i];
-                var mesh = bone?.MeshReference?.Mesh;
-                if (mesh != null)
-                {
+			for (int i = 0; i < skeleton.Skeleton.Count; i++)
+			{
+				var bone = skeleton.Skeleton[i];
+				var mesh = bone?.MeshReference?.Mesh;
+				if (mesh != null)
+				{
                     var originalVertices = MeshExportHelper.ShiftMeshVertices(mesh, skeleton,
-                        wldFile.WldType == WldType.Characters, "pos", 0, i, true);
+						wldFile.WldType == WldType.Characters, "pos", 0, i, true);
 
-                    gltfWriter.AddFragmentData(mesh, skeleton, i);
+					gltfWriter.AddFragmentData(mesh, skeleton, i);
 
                     mesh.Vertices = originalVertices;
-                }
-            }
+				}
+			}
 
-            if (skeleton.Meshes != null)
-            {
-                foreach (var mesh in skeleton.Meshes)
-                {
-                    var originalVertices = MeshExportHelper.ShiftMeshVertices(mesh, skeleton,
-                        wldFile.WldType == WldType.Characters, "pos", 0);
+			if (skeleton.Meshes != null)
+			{
+				foreach (var mesh in skeleton.Meshes)
+				{
+					var originalVertices = MeshExportHelper.ShiftMeshVertices(mesh, skeleton,
+						wldFile.WldType == WldType.Characters, "pos", 0);
 
-                    gltfWriter.AddFragmentData(mesh, skeleton);
+					gltfWriter.AddFragmentData(mesh, skeleton);
 
                     mesh.Vertices = originalVertices;
-                }
-            }
+				}
+			}
 
-            if (settings.ExportAllAnimationFrames)
-            {
-                gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", wldFile.WldType == WldType.Characters, true);
+			if (settings.ExportAllAnimationFrames)
+			{
+				gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", wldFile.WldType == WldType.Characters, true);
 
                 foreach (var animationKey in skeleton.Animations.Keys
                     .Where(a => a == "pos" ||
                         settings.ExportedAnimationTypes.Contains(a.Substring(0, 1).ToLower()))
-                    .OrderBy(k => k, new AnimationKeyComparer()))
-                {
-                    gltfWriter.ApplyAnimationToSkeleton(skeleton, animationKey,
-                        wldFile.WldType == WldType.Characters, false);
-                }
-            }
+					.OrderBy(k => k, new AnimationKeyComparer()))
+				{
+					gltfWriter.ApplyAnimationToSkeleton(skeleton, animationKey,
+						wldFile.WldType == WldType.Characters, false);
+				}
+			}
 
-            var exportFilePath = $"{exportFolder}{FragmentNameCleaner.CleanName(skeleton)}.gltf";
-            gltfWriter.WriteAssetToFile(exportFilePath, true, skeleton.ModelBase);
-        }
+			var exportFilePath = $"{exportFolder}{FragmentNameCleaner.CleanName(skeleton)}.gltf";
+			gltfWriter.WriteAssetToFile(exportFilePath, true, skeleton.ModelBase);
+		}
 
         private static void ExportZoneCharacterVariations(WldFileCharacters wldChrFile, Settings settings,
             ILogger logger)
         {
-            var zoneName = wldChrFile.ZoneShortname;
+			var zoneName = wldChrFile.ZoneShortname;
 
-            var zonePcsWithVariations = GlobalReference.ServerDatabaseConnector
+			var zonePcsWithVariations = GlobalReference.ServerDatabaseConnector
                 .QueryPlayerCharactersInZoneFromDatabase(zoneName);
             var zoneGlobalCharacters = GlobalReference.ServerDatabaseConnector
                 .QueryGlobalNpcsInZone(zoneName);
@@ -384,28 +384,28 @@ namespace LanternExtractor.EQ.Wld.Exporters
             var allUniqueHeldEquipmentIds = GetUniqueHeldEquipmentIds(
                 zonePcsWithVariations, zoneGlobalCharacters, zoneNpcsWithVariations);
 
-            var translator = GlobalReference.NpcDatabaseToClientTranslator;
-            var groupedZoneGlobalCharacters = zoneGlobalCharacters.ToLookup(
-                c => translator.GetClientModelForRaceIdAndGender(c.Race, (int)c.Gender));
-            var groupedZonePcsWithVariations = zonePcsWithVariations.ToLookup(
-                p => p.Item2.RaceGender);
-            var uniqueGlobalActors = groupedZoneGlobalCharacters.Select(g => g.Key)
+			var translator = GlobalReference.NpcDatabaseToClientTranslator;
+			var groupedZoneGlobalCharacters = zoneGlobalCharacters.ToLookup(
+				c => translator.GetClientModelForRaceIdAndGender(c.Race, (int)c.Gender));
+			var groupedZonePcsWithVariations = zonePcsWithVariations.ToLookup(
+				p => p.Item2.RaceGender);
+			var uniqueGlobalActors = groupedZoneGlobalCharacters.Select(g => g.Key)
                 .Union(groupedZonePcsWithVariations.Select(g => g.Key));
 
             var wldEqFile = ArchiveExtractor.InitWldsForZoneCharacterVariationExport(
-                uniqueGlobalActors, allUniqueHeldEquipmentIds, wldChrFile.RootExportFolder,
+                uniqueGlobalActors, allUniqueHeldEquipmentIds, wldChrFile.RootExportFolder, 
                 zoneName, logger, settings);
 
             var groupedZoneNpcsWithVariants = zoneNpcsWithVariations.ToLookup(
                 n => translator.GetClientModelForRaceIdAndGender(n.Race, (int)n.Gender));
-
+            
             foreach (var actorName in groupedZonePcsWithVariations.Select(g => g.Key))
             {
                 PlayerCharacterGltfExporter.ExportPlayerCharacterVariationsForActor(
                     actorName, groupedZonePcsWithVariations[actorName], GlobalReference.CharacterWld,
                     wldEqFile, zoneName, logger, settings);
             }
-
+                
             foreach (var actorName in groupedZoneGlobalCharacters.Select(g => g.Key))
             {
                 var lookupName = $"{actorName}_ACTORDEF";
@@ -419,14 +419,14 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
             foreach (var actorName in groupedZoneNpcsWithVariants.Select(g => g.Key))
             {
-                var lookupName = $"{actorName}_ACTORDEF";
+				var lookupName = $"{actorName}_ACTORDEF";
 
-                var actor = wldChrFile.GetFragmentByNameIncludingInjectedWlds<Actor>(lookupName);
+				var actor = wldChrFile.GetFragmentByNameIncludingInjectedWlds<Actor>(lookupName);
 
-                ExportActorNpcVariations(actor, settings, wldChrFile,
-                    groupedZoneNpcsWithVariants[actorName], wldEqFile, zoneName, logger);
-            }
-        }
+				ExportActorNpcVariations(actor, settings, wldChrFile,
+					groupedZoneNpcsWithVariants[actorName], wldEqFile, zoneName, logger);
+			}
+		}
 
         private static void FixElementals(IEnumerable<Npc> globalNpcs)
         {
@@ -434,18 +434,18 @@ namespace LanternExtractor.EQ.Wld.Exporters
             globalNpcs.Where(n => n.Race == 209).ToList().ForEach(
                 n => { n.Race = 75; n.Texture = 0; });
 
-            // Fire
-            globalNpcs.Where(n => n.Race == 212).ToList().ForEach(
-                n => { n.Race = 75; n.Texture = 1; });
+			// Fire
+			globalNpcs.Where(n => n.Race == 212).ToList().ForEach(
+				n => { n.Race = 75; n.Texture = 1; });
 
-            // Water
-            globalNpcs.Where(n => n.Race == 211).ToList().ForEach(
-                n => { n.Race = 75; n.Texture = 2; });
+			// Water
+			globalNpcs.Where(n => n.Race == 211).ToList().ForEach(
+	            n => { n.Race = 75; n.Texture = 2; });
 
-            // Air
-            globalNpcs.Where(n => n.Race == 210).ToList().ForEach(
-                n => { n.Race = 75; n.Texture = 3; });
-        }
+			// Air
+			globalNpcs.Where(n => n.Race == 210).ToList().ForEach(
+	            n => { n.Race = 75; n.Texture = 3; });
+		}
 
         private static IEnumerable<string> GetUniqueHeldEquipmentIds(
             IEnumerable<(string, PlayerCharacterModel)> zonePcsWithVariations,
@@ -453,184 +453,184 @@ namespace LanternExtractor.EQ.Wld.Exporters
             IEnumerable<Npc> zoneNpcsWithVariations)
         {
             return zonePcsWithVariations.Where(p => p.Item2.Primary_ID != null)
-                    .Select(p => p.Item2.Primary_ID)
-                    .Union(
-                        zonePcsWithVariations.Where(p => p.Item2.Secondary_ID != null)
-                            .Select(p => p.Item2.Secondary_ID))
-                    .Union(
-                        zoneGlobalCharacters.Where(c => c.Primary > 0)
-                            .Select(c => $"IT{c.Primary}"))
-                    .Union(
-                        zoneGlobalCharacters.Where(c => c.Secondary > 0)
-                            .Select(c => $"IT{c.Secondary}"))
-                    .Union(
-                        zoneNpcsWithVariations.Where(c => c.Primary > 0)
-                            .Select(c => $"IT{c.Primary}"))
-                    .Union(
-                        zoneNpcsWithVariations.Where(c => c.Secondary > 0)
-                            .Select(c => $"IT{c.Secondary}"))
-                    .Distinct();
-        }
+					.Select(p => p.Item2.Primary_ID)
+					.Union(
+						zonePcsWithVariations.Where(p => p.Item2.Secondary_ID != null)
+							.Select(p => p.Item2.Secondary_ID))
+					.Union(
+						zoneGlobalCharacters.Where(c => c.Primary > 0)
+							.Select(c => $"IT{c.Primary}"))
+					.Union(
+						zoneGlobalCharacters.Where(c => c.Secondary > 0)
+							.Select(c => $"IT{c.Secondary}"))
+					.Union(
+						zoneNpcsWithVariations.Where(c => c.Primary > 0)
+							.Select(c => $"IT{c.Primary}"))
+					.Union(
+						zoneNpcsWithVariations.Where(c => c.Secondary > 0)
+							.Select(c => $"IT{c.Secondary}"))
+					.Distinct();
+		}
 
         private static void ExportActorNpcVariations(Actor actor, Settings settings, WldFile wldFile,
-            IEnumerable<Npc> npcVariations, WldFileEquipment wldEqFile, string zoneName, ILogger logger)
+			IEnumerable<Npc> npcVariations, WldFileEquipment wldEqFile, string zoneName, ILogger logger)
         {
-            var skeleton = actor?.SkeletonReference?.SkeletonHierarchy;
+			var skeleton = actor?.SkeletonReference?.SkeletonHierarchy;
 
-            if (skeleton == null) return;
+			if (skeleton == null) return;
 
             if (skeleton.Meshes == null) return;
 
-            var actorName = FragmentNameCleaner.CleanName(skeleton);
+			var actorName = FragmentNameCleaner.CleanName(skeleton);
 
-            if (settings.ExportAllAnimationFrames)
-            {
-                GlobalReference.CharacterWld.AddAdditionalAnimationsToSkeleton(skeleton);
-            }
+			if (settings.ExportAllAnimationFrames)
+			{
+				GlobalReference.CharacterWld.AddAdditionalAnimationsToSkeleton(skeleton);
+			}
 
-            var exportFormat = settings.ExportGltfInGlbFormat ? GltfExportFormat.Glb : GltfExportFormat.GlTF;
-            var gltfWriterForCommonMaterials = new GltfWriter(settings, exportFormat, logger);
+			var exportFormat = settings.ExportGltfInGlbFormat ? GltfExportFormat.Glb : GltfExportFormat.GlTF;
+			var gltfWriterForCommonMaterials = new GltfWriter(settings, exportFormat, logger);
 
-            var materialLists = GatherMaterialLists(new List<WldFragment>() { skeleton });
-            var exportFolder = Path.Combine(wldFile.RootExportFolder, zoneName, "Characters");
+			var materialLists = GatherMaterialLists(new List<WldFragment>() { skeleton });
+			var exportFolder = Path.Combine(wldFile.RootExportFolder, zoneName, "Characters");
 
             var textureImageFolder = Path.Combine(exportFolder, "Textures");
-            gltfWriterForCommonMaterials.GenerateGltfMaterials(materialLists, textureImageFolder, npcVariations != null);
+			gltfWriterForCommonMaterials.GenerateGltfMaterials(materialLists, textureImageFolder, npcVariations != null);
 
-            var variationGltfWriters = new Dictionary<Npc, GltfWriter>();
-            var heldEquipmentMeshes = new Dictionary<int, WldFragment>();
+			var variationGltfWriters = new Dictionary<Npc, GltfWriter>();
+			var heldEquipmentMeshes = new Dictionary<int, WldFragment>();
 
-            foreach (var npc in npcVariations)
-            {
-                var variationWriter = new GltfWriter(settings, exportFormat, logger);
-                variationWriter.CopyMaterialList(gltfWriterForCommonMaterials);
-                var equipmentFragments = new List<WldFragment>();
-                if (npc.Primary > 0)
-                {
-                    if (!heldEquipmentMeshes.TryGetValue(npc.Primary, out var primaryMeshOrSkeleton))
-                    {
-                        primaryMeshOrSkeleton = GltfCharacterHeldEquipmentHelper.GetMeshOrSkeletonForCharacterHeldEquipment
-                            ($"IT{npc.Primary}", wldEqFile, logger);
-                        heldEquipmentMeshes.Add(npc.Primary, primaryMeshOrSkeleton);
-                    }
-                    equipmentFragments.Add(primaryMeshOrSkeleton);
-                }
-                if (npc.Secondary > 0)
-                {
-                    if (!heldEquipmentMeshes.TryGetValue(npc.Secondary, out var secondaryMeshOrSkeleton))
-                    {
-                        secondaryMeshOrSkeleton = GltfCharacterHeldEquipmentHelper.GetMeshOrSkeletonForCharacterHeldEquipment
-                            ($"IT{npc.Secondary}", wldEqFile, logger);
-                        heldEquipmentMeshes.Add(npc.Secondary, secondaryMeshOrSkeleton);
-                    }
-                    equipmentFragments.Add(secondaryMeshOrSkeleton);
-                }
-                if (equipmentFragments.Any())
-                {
-                    var eqMaterialLists = GatherMaterialLists(equipmentFragments);
-                    variationWriter.GenerateGltfMaterials(eqMaterialLists, textureImageFolder);
-                }
-                variationGltfWriters.Add(npc, variationWriter);
-            }
+			foreach (var npc in npcVariations)
+			{
+				var variationWriter = new GltfWriter(settings, exportFormat, logger);
+				variationWriter.CopyMaterialList(gltfWriterForCommonMaterials);
+				var equipmentFragments = new List<WldFragment>();
+				if (npc.Primary > 0)
+				{
+					if (!heldEquipmentMeshes.TryGetValue(npc.Primary, out var primaryMeshOrSkeleton))
+					{
+						primaryMeshOrSkeleton = GltfCharacterHeldEquipmentHelper.GetMeshOrSkeletonForCharacterHeldEquipment
+							($"IT{npc.Primary}", wldEqFile, logger);
+						heldEquipmentMeshes.Add(npc.Primary, primaryMeshOrSkeleton);
+					}
+					equipmentFragments.Add(primaryMeshOrSkeleton);
+				}
+				if (npc.Secondary > 0)
+				{
+					if (!heldEquipmentMeshes.TryGetValue(npc.Secondary, out var secondaryMeshOrSkeleton))
+					{
+						secondaryMeshOrSkeleton = GltfCharacterHeldEquipmentHelper.GetMeshOrSkeletonForCharacterHeldEquipment
+							($"IT{npc.Secondary}", wldEqFile, logger);
+						heldEquipmentMeshes.Add(npc.Secondary, secondaryMeshOrSkeleton);
+					}
+					equipmentFragments.Add(secondaryMeshOrSkeleton);
+				}
+				if (equipmentFragments.Any())
+				{
+					var eqMaterialLists = GatherMaterialLists(equipmentFragments);
+					variationWriter.GenerateGltfMaterials(eqMaterialLists, textureImageFolder);
+				}
+				variationGltfWriters.Add(npc, variationWriter);
+			}
 
             // Out of the loop to ensure it's done only once per mesh
             var preShiftedVerticesForMeshes = new Dictionary<string, List<GlmSharp.vec3>>();
-            foreach (var mesh in skeleton.Meshes.Union(skeleton.SecondaryMeshes))
-            {
-                var originalVertices = MeshExportHelper.ShiftMeshVertices(mesh, skeleton,
-                    wldFile.WldType == WldType.Characters, "pos", 0);
+			foreach (var mesh in skeleton.Meshes.Union(skeleton.SecondaryMeshes))
+			{
+				var originalVertices = MeshExportHelper.ShiftMeshVertices(mesh, skeleton,
+					wldFile.WldType == WldType.Characters, "pos", 0);
                 preShiftedVerticesForMeshes.Add(mesh.Name, originalVertices);
-            }
+			}
             var boneMeshes = new List<Mesh>();
-            for (int i = 0; i < skeleton.Skeleton.Count; i++)
-            {
-                var mesh = skeleton.Skeleton[i]?.MeshReference?.Mesh;
-                if (mesh != null)
-                {
-                    var originalVertices = MeshExportHelper.ShiftMeshVertices(mesh, skeleton,
-                        wldFile.WldType == WldType.Characters, "pos", 0, i, true);
+			for (int i = 0; i < skeleton.Skeleton.Count; i++)
+			{
+				var mesh = skeleton.Skeleton[i]?.MeshReference?.Mesh;
+				if (mesh != null)
+				{
+					var originalVertices = MeshExportHelper.ShiftMeshVertices(mesh, skeleton,
+						wldFile.WldType == WldType.Characters, "pos", 0, i, true);
                     preShiftedVerticesForMeshes.Add(mesh.Name, originalVertices);
                     boneMeshes.Add(mesh);
-                }
-            }
+				}
+			}
 
-            foreach (var npc in npcVariations)
-            {
+			foreach (var npc in npcVariations)
+			{
                 if (skeleton.Meshes != null && skeleton.Meshes.Any())
                 {
                     var meshes = new List<Mesh>() { skeleton.Meshes[0] };
-                    if (npc.HelmTexture > 0 && skeleton.SecondaryMeshes.Any())
-                    {
-                        meshes.Add(skeleton.SecondaryMeshes[npc.HelmTexture - 1]);
-                    }
-                    else if (skeleton.Meshes.Count > 1)
-                    {
-                        meshes.Add(skeleton.Meshes[1]);
-                    }
-                    foreach (var mesh in meshes)
-                    {
-                        variationGltfWriters[npc].AddFragmentData(mesh, skeleton, -1, npc);
-                    }
-                }
+					if (npc.HelmTexture > 0 && skeleton.SecondaryMeshes.Any())
+					{
+						meshes.Add(skeleton.SecondaryMeshes[npc.HelmTexture - 1]);
+					}
+					else if (skeleton.Meshes.Count > 1)
+					{
+						meshes.Add(skeleton.Meshes[1]);
+					}
+					foreach (var mesh in meshes)
+					{
+						variationGltfWriters[npc].AddFragmentData(mesh, skeleton, -1, npc);
+					}
+				}
                 else
                 {
-                    for (int i = 0; i < skeleton.Skeleton.Count; i++)
-                    {
-                        var mesh = skeleton.Skeleton[i]?.MeshReference?.Mesh;
-                        if (mesh != null)
-                        {
-                            variationGltfWriters[npc].AddFragmentData(mesh, skeleton, i, npc);
-                        }
-                    }
-                }
+					for (int i = 0; i < skeleton.Skeleton.Count; i++)
+					{
+						var mesh = skeleton.Skeleton[i]?.MeshReference?.Mesh;
+						if (mesh != null)
+						{
+							variationGltfWriters[npc].AddFragmentData(mesh, skeleton, i, npc);
+						}
+					}
+				}
 
-                var boneIndexOffset = skeleton.Skeleton.Count;
-                if (npc.Primary > 0)
-                {
-                    GltfCharacterHeldEquipmentHelper.AddCharacterHeldEquipmentToGltfWriter
-                        (heldEquipmentMeshes[npc.Primary], $"IT{npc.Primary}", skeleton, "r_point",
-                            variationGltfWriters[npc], ref boneIndexOffset);
-                }
-                if (npc.Secondary > 0)
-                {
-                    var secondaryAttachBone = GltfCharacterHeldEquipmentHelper.IsShield($"IT{npc.Secondary}") ?
-                        "shield_point" : "l_point";
-                    GltfCharacterHeldEquipmentHelper.AddCharacterHeldEquipmentToGltfWriter
-                        (heldEquipmentMeshes[npc.Secondary], $"IT{npc.Secondary}", skeleton, secondaryAttachBone,
-                            variationGltfWriters[npc], ref boneIndexOffset);
-                }
-            }
+				var boneIndexOffset = skeleton.Skeleton.Count;
+				if (npc.Primary > 0)
+				{
+					GltfCharacterHeldEquipmentHelper.AddCharacterHeldEquipmentToGltfWriter
+						(heldEquipmentMeshes[npc.Primary], $"IT{npc.Primary}", skeleton, "r_point",
+							variationGltfWriters[npc], ref boneIndexOffset);
+				}
+				if (npc.Secondary > 0)
+				{
+					var secondaryAttachBone = GltfCharacterHeldEquipmentHelper.IsShield($"IT{npc.Secondary}") ?
+						"shield_point" : "l_point";
+					GltfCharacterHeldEquipmentHelper.AddCharacterHeldEquipmentToGltfWriter
+						(heldEquipmentMeshes[npc.Secondary], $"IT{npc.Secondary}", skeleton, secondaryAttachBone,
+							variationGltfWriters[npc], ref boneIndexOffset);
+				}
+			}
 
-            foreach (var mesh in skeleton.Meshes.Union(skeleton.SecondaryMeshes).Union(boneMeshes))
-            {
+			foreach (var mesh in skeleton.Meshes.Union(skeleton.SecondaryMeshes).Union(boneMeshes))
+			{
                 mesh.Vertices = preShiftedVerticesForMeshes[mesh.Name];
-            }
+			}
 
-            if (settings.ExportAllAnimationFrames)
-            {
-                foreach (var gltfWriter in variationGltfWriters.Values)
-                {
-                    gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", wldFile.WldType == WldType.Characters, true);
+			if (settings.ExportAllAnimationFrames)
+			{
+				foreach (var gltfWriter in variationGltfWriters.Values)
+				{
+					gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", wldFile.WldType == WldType.Characters, true);
 
-                    foreach (var animationKey in skeleton.Animations.Keys
-                        .Where(a => settings.ExportedAnimationTypes.Contains(a.Substring(0, 1).ToLower()))
-                        .OrderBy(k => k, new AnimationKeyComparer()))
-                    {
-                        gltfWriter.ApplyAnimationToSkeleton(skeleton, animationKey,
-                            wldFile.WldType == WldType.Characters, false);
-                    }
-                }
-            }
+					foreach (var animationKey in skeleton.Animations.Keys
+						.Where(a => settings.ExportedAnimationTypes.Contains(a.Substring(0, 1).ToLower()))
+						.OrderBy(k => k, new AnimationKeyComparer()))
+					{
+						gltfWriter.ApplyAnimationToSkeleton(skeleton, animationKey,
+							wldFile.WldType == WldType.Characters, false);
+					}
+				}
+			}
 
-            foreach (var variationGltfWriter in variationGltfWriters)
-            {
-                var fileName = GetUniqueNpcString(actorName, variationGltfWriter.Key);
-                var exportFilePath = Path.Combine(exportFolder, $"{fileName}.gltf");
-                variationGltfWriter.Value.WriteAssetToFile(exportFilePath, true, skeleton.ModelBase);
-            }
-        }
+			foreach (var variationGltfWriter in variationGltfWriters)
+			{
+				var fileName = GetUniqueNpcString(actorName, variationGltfWriter.Key);
+				var exportFilePath = Path.Combine(exportFolder, $"{fileName}.gltf");
+				variationGltfWriter.Value.WriteAssetToFile(exportFilePath, true, skeleton.ModelBase);
+			}
+		}
 
-        private static void ExportSky(Settings settings, WldFile skyWld, ILogger logger)
+		private static void ExportSky(Settings settings, WldFile skyWld, ILogger logger)
         {
             var skySkeletons = skyWld.GetFragmentsOfType<SkeletonHierarchy>();
             var skySkeletonMeshNames = new List<string>();

--- a/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
@@ -206,13 +206,13 @@ namespace LanternExtractor.EQ.Wld.Exporters
             "otplant103b",
             "otplant103c"
         };
-        private static readonly float ZoneScaleMultiplier = 0.2f;
-        private static readonly Matrix4x4 MirrorXAxisMatrix = Matrix4x4.CreateReflection(new Plane(1, 0, 0, 0));
-        private static readonly Matrix4x4 CorrectedWorldMatrix = MirrorXAxisMatrix * Matrix4x4.CreateScale(ZoneScaleMultiplier);
+        private readonly float ZoneScaleMultiplier;
+        private readonly Matrix4x4 CorrectedWorldMatrix;
+        public static readonly Matrix4x4 MirrorXAxisMatrix = Matrix4x4.CreateReflection(new Plane(1, 0, 0, 0));
         private static readonly Matrix4x4 CorrectedSingularActorMatrix = Matrix4x4.CreateReflection(new Plane(0, 0, 1, 0));
-		#endregion
+        #endregion
 
-		private SceneBuilder _scene;
+        private SceneBuilder _scene;
         private IMeshBuilder<MaterialBuilder> _combinedMeshBuilder;
         private ISet<string> _meshMaterialsToSkip;
         private IDictionary<string, IMeshBuilder<MaterialBuilder>> _sharedMeshes;
@@ -220,31 +220,32 @@ namespace LanternExtractor.EQ.Wld.Exporters
         private IDictionary<string, List<(string, string)>> _skeletonChildrenAttachBones;
         private bool _separateTwoFacedTriangles;
 
-        public GltfWriter(bool exportVertexColors, GltfExportFormat exportFormat, ILogger logger, bool separateTwoFacedTriangles = false)
+        public GltfWriter(Settings settings, GltfExportFormat exportFormat, ILogger logger)
         {
-            _exportVertexColors = exportVertexColors;
+            _exportVertexColors = settings.ExportGltfVertexColors;
             _exportFormat = exportFormat;
             _logger = logger;
-
+            ZoneScaleMultiplier = settings.ExportZoneScale;
+            CorrectedWorldMatrix = Matrix4x4.CreateScale(ZoneScaleMultiplier);
             Materials = new Dictionary<string, MaterialBuilder>();
             _meshMaterialsToSkip = new HashSet<string>();
             _skeletons = new Dictionary<string, List<NodeBuilder>>();
             _skeletonChildrenAttachBones = new Dictionary<string, List<(string, string)>>();
             _sharedMeshes = new Dictionary<string, IMeshBuilder<MaterialBuilder>>();
-            _separateTwoFacedTriangles = separateTwoFacedTriangles;
+            _separateTwoFacedTriangles = settings.SeparateTwoFacedTriangles;
             _scene = new SceneBuilder();
         }
 
         public override void AddFragmentData(WldFragment fragment)
         {
             AddFragmentData(
-                mesh:(Mesh)fragment, 
-                generationMode:ModelGenerationMode.Separate );
+                mesh: (Mesh)fragment,
+                generationMode: ModelGenerationMode.Separate);
         }
 
-        public void AddFragmentData(Mesh mesh, SkeletonHierarchy skeleton, int singularBoneIndex = -1, 
-            ICharacterModel characterModel = null, string parentSkeletonName = null, string parentSkeletonAttachBoneName = null, 
-            string meshNameOverride = null, bool usesMobPieces = false )
+        public void AddFragmentData(Mesh mesh, SkeletonHierarchy skeleton, int singularBoneIndex = -1,
+            ICharacterModel characterModel = null, string parentSkeletonName = null, string parentSkeletonAttachBoneName = null,
+            string meshNameOverride = null, bool usesMobPieces = false)
         {
             if (!_skeletons.ContainsKey(skeleton.ModelBase))
             {
@@ -252,10 +253,10 @@ namespace LanternExtractor.EQ.Wld.Exporters
             }
 
             AddFragmentData(
-                mesh: mesh, 
-                generationMode: ModelGenerationMode.Combine, 
-                isSkinned: true, 
-                meshNameOverride: meshNameOverride, 
+                mesh: mesh,
+                generationMode: ModelGenerationMode.Combine,
+                isSkinned: true,
+                meshNameOverride: meshNameOverride,
                 singularBoneIndex: singularBoneIndex,
                 usesMobPieces: usesMobPieces,
                 characterModel: characterModel);
@@ -292,26 +293,26 @@ namespace LanternExtractor.EQ.Wld.Exporters
         }
 
         public void AddFragmentData(
-            Mesh mesh, 
-            ModelGenerationMode generationMode, 
-            bool isSkinned = false, 
+            Mesh mesh,
+            ModelGenerationMode generationMode,
+            bool isSkinned = false,
             string meshNameOverride = null,
-            int singularBoneIndex = -1, 
-            ObjInstance objectInstance = null, 
+            int singularBoneIndex = -1,
+            ObjInstance objectInstance = null,
             int instanceIndex = 0,
             bool isZoneMesh = false,
             bool usesMobPieces = false,
             ICharacterModel characterModel = null)
         {
             var meshName = meshNameOverride ?? FragmentNameCleaner.CleanName(mesh);
-			var transformMatrix = objectInstance == null ? Matrix4x4.Identity : CreateTransformMatrixForObjectInstance(objectInstance);
-			transformMatrix = transformMatrix *= isZoneMesh ? CorrectedWorldMatrix : MirrorXAxisMatrix;
+            var transformMatrix = objectInstance == null ? Matrix4x4.Identity : CreateTransformMatrixForObjectInstance(objectInstance);
+            transformMatrix = transformMatrix *= isZoneMesh ? CorrectedWorldMatrix : Matrix4x4.Identity;
 
-			var canExportVertexColors = _exportVertexColors &&
+            var canExportVertexColors = _exportVertexColors &&
                 ((objectInstance?.Colors?.Colors != null && objectInstance.Colors.Colors.Any())
                 || (mesh?.Colors != null && mesh.Colors.Any()));
-            
-            if (mesh.AnimatedVerticesReference == null && !canExportVertexColors && objectInstance != null && 
+
+            if (mesh.AnimatedVerticesReference == null && !canExportVertexColors && objectInstance != null &&
                 _sharedMeshes.TryGetValue(meshName, out var existingMesh))
             {
                 if (generationMode == ModelGenerationMode.Separate)
@@ -343,9 +344,9 @@ namespace LanternExtractor.EQ.Wld.Exporters
             // Keeping track of vertex indexes for each vertex position in case it's an
             // animated mesh so we can create morph targets later
             var gltfVertexPositionToWldVertexIndex = new Dictionary<VertexPositionNormal, int>();
-            
+
             var polygonIndex = 0;
-            var meshHelper = new WldMeshHelper(mesh, _separateTwoFacedTriangles);
+            var meshHelper = new WldMeshHelper(mesh, _separateTwoFacedTriangles, isZoneMesh);
             foreach (var materialGroup in mesh.MaterialGroups)
             {
                 var material = mesh.MaterialList.Materials[materialGroup.MaterialIndex];
@@ -354,14 +355,14 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 {
                     if (characterModel.TryGetMaterialVariation(material.GetFirstBitmapNameWithoutExtension(), out var variationIndex, out var color))
                     {
-						var alternateSkins = mesh.MaterialList.GetMaterialVariants(material, _logger);
-						if (alternateSkins.Any() && alternateSkins.Count() > variationIndex && alternateSkins.ElementAt(variationIndex) != null)
-						{
-							material = alternateSkins[variationIndex];
-						}
+                        var alternateSkins = mesh.MaterialList.GetMaterialVariants(material, _logger);
+                        if (alternateSkins.Any() && alternateSkins.Count() > variationIndex && alternateSkins.ElementAt(variationIndex) != null)
+                        {
+                            material = alternateSkins[variationIndex];
+                        }
                     }
-					baseColor = color;
-				}
+                    baseColor = color;
+                }
                 var materialName = GetMaterialName(material);
 
                 if (_meshMaterialsToSkip.Contains(materialName) || (characterModel != null && characterModel.ShouldSkipMeshGenerationForMaterial(materialName)))
@@ -387,22 +388,22 @@ namespace LanternExtractor.EQ.Wld.Exporters
                     if (!canExportVertexColors && !isSkinned)
                     {
                         triangleGtlfVpToWldVi = AddTriangleToMesh<VertexPositionNormal, VertexTexture1, VertexEmpty>
-                            (primitive, meshHelper, polygonIndex++, canExportVertexColors, isSkinned, singularBoneIndex, usesMobPieces, objectInstance);
+                            (primitive, meshHelper, polygonIndex++, canExportVertexColors, isSkinned, singularBoneIndex, usesMobPieces, objectInstance, isZoneMesh);
                     }
                     else if (!canExportVertexColors && isSkinned)
                     {
                         triangleGtlfVpToWldVi = AddTriangleToMesh<VertexPositionNormal, VertexTexture1, VertexJoints4>
-                            (primitive, meshHelper, polygonIndex++, canExportVertexColors, isSkinned, singularBoneIndex, usesMobPieces, objectInstance);
+                            (primitive, meshHelper, polygonIndex++, canExportVertexColors, isSkinned, singularBoneIndex, usesMobPieces, objectInstance, isZoneMesh);
                     }
                     else if (canExportVertexColors && !isSkinned)
                     {
                         triangleGtlfVpToWldVi = AddTriangleToMesh<VertexPositionNormal, VertexColor1Texture1, VertexEmpty>
-                            (primitive, meshHelper, polygonIndex++, canExportVertexColors, isSkinned, singularBoneIndex, usesMobPieces, objectInstance);
+                            (primitive, meshHelper, polygonIndex++, canExportVertexColors, isSkinned, singularBoneIndex, usesMobPieces, objectInstance, isZoneMesh);
                     }
                     else //(canExportVertexColors && isSkinned)
                     {
                         triangleGtlfVpToWldVi = AddTriangleToMesh<VertexPositionNormal, VertexColor1Texture1, VertexJoints4>
-                            (primitive, meshHelper, polygonIndex++, canExportVertexColors, isSkinned, singularBoneIndex, usesMobPieces, objectInstance);
+                            (primitive, meshHelper, polygonIndex++, canExportVertexColors, isSkinned, singularBoneIndex, usesMobPieces, objectInstance, isZoneMesh);
                     }
                     triangleGtlfVpToWldVi.ToList().ForEach(kv => gltfVertexPositionToWldVertexIndex[kv.Key] = kv.Value);
                 }
@@ -415,19 +416,19 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 if (mesh.AnimatedVerticesReference != null &&
                         !AnimatedMeshesSharpGltfWillNotExportMorphTargets.Contains(FragmentNameCleaner.CleanName(mesh, true)))
                 {
-                    AddAnimatedMeshMorphTargets(mesh, gltfMesh, meshName, transformMatrix, gltfVertexPositionToWldVertexIndex);
+                    AddAnimatedMeshMorphTargets(mesh, gltfMesh, meshName, transformMatrix, gltfVertexPositionToWldVertexIndex, isZoneMesh);
                     // mesh added to scene in ^ method
                 }
                 else if (AnimatedDoorObjectOpenTypes.TryGetValue(meshName, out var openType))
                 {
                     var node = GetDoorAnimationNodeForOpenType(openType, meshName, transformMatrix);
-					_scene.AddRigidMesh(gltfMesh, node);
-				}
+                    _scene.AddRigidMesh(gltfMesh, node);
+                }
                 else
                 {
                     _scene.AddRigidMesh(gltfMesh, new AffineTransform(transformMatrix));
                     _sharedMeshes[meshName] = gltfMesh;
-                }              
+                }
             }
         }
 
@@ -445,7 +446,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
             var poseArray = isCharacterAnimation
                 ? skeleton.Animations[DefaultModelPoseAnimationKey].TracksCleanedStripped
                 : skeleton.Animations[DefaultModelPoseAnimationKey].TracksCleaned;
-            
+
             if (poseArray == null) return;
             var hasChildren = _skeletonChildrenAttachBones.TryGetValue(skeleton.ModelBase, out var skeletonChildrenAttachBones);
             for (var i = 0; i < skeleton.Skeleton.Count; i++)
@@ -522,19 +523,19 @@ namespace LanternExtractor.EQ.Wld.Exporters
                     var position = lightInstance.Position.ToVector3(swapYandZ: true);
                     var translationMatrix = Matrix4x4.CreateTranslation(position) * CorrectedWorldMatrix;
                     Matrix4x4.Decompose(translationMatrix, out _, out _, out var translation);
-					var lightName = lightInstance.LightReference?.LightSource?.Name;
-					var node = new NodeBuilder(lightName != null ? lightName.Split('_')[0] : "");
-					// node.WithTranslation(translation) makes VS complain for some reason
-					node.LocalTransform = node.LocalTransform.WithTranslation(translation);
-					_scene.AddLight(light, node);
+                    var lightName = lightInstance.LightReference?.LightSource?.Name;
+                    var node = new NodeBuilder(lightName != null ? lightName.Split('_')[0] : "");
+                    // node.WithTranslation(translation) makes VS complain for some reason
+                    node.LocalTransform = node.LocalTransform.WithTranslation(translation);
+                    _scene.AddLight(light, node);
                 }
             }
-		}
+        }
 
         public void AddCombinedMeshToScene(
-            bool isZoneMesh = false, 
-            string meshName = null, 
-            string skeletonModelBase = null, 
+            bool isZoneMesh = false,
+            string meshName = null,
+            string skeletonModelBase = null,
             ObjInstance objectInstance = null,
             int? instanceIndex = null)
         {
@@ -549,8 +550,8 @@ namespace LanternExtractor.EQ.Wld.Exporters
             }
             if (combinedMesh == null) return;
 
-			var skeletonName = GetSkeletonName(skeletonModelBase, instanceIndex);
-			
+            var skeletonName = GetSkeletonName(skeletonModelBase, instanceIndex);
+
             var worldTransformMatrix = Matrix4x4.Identity;
             if (objectInstance != null && skeletonName == null)
             {
@@ -584,7 +585,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
                     worldTransformMatrix = skeletonNodes[0].Parent.WorldMatrix;
                 }
 
-                _scene.AddSkinnedMesh(combinedMesh, worldTransformMatrix, skeletonNodes.ToArray());       
+                _scene.AddSkinnedMesh(combinedMesh, worldTransformMatrix, skeletonNodes.ToArray());
             }
 
             if (meshName != null && !_sharedMeshes.ContainsKey(meshName))
@@ -603,7 +604,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
         {
             AddCombinedMeshToScene(false, null, skeletonModelBase);
 
-			var outputFilePath = FixFilePath(fileName);
+            var outputFilePath = FixFilePath(fileName);
             var model = _scene.ToGltf2();
 
             if (_exportFormat == GltfExportFormat.GlTF)
@@ -638,7 +639,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
                             return $"Textures/{Path.GetFileName(imageSourcePath)}";
                         }
                     };
-					model.SaveGLTF(outputFilePath, writeSettings);
+                    model.SaveGLTF(outputFilePath, writeSettings);
                 }
             }
             else // Glb
@@ -652,63 +653,63 @@ namespace LanternExtractor.EQ.Wld.Exporters
             }
         }
 
-		public List<NodeBuilder> AddNewSkeleton(SkeletonHierarchy skeleton, string parent = null, string attachBoneName = null, ObjInstance objInstance = null, int? instanceIndex = null)
-		{
-			var skeletonNodes = new List<NodeBuilder>();
-			var duplicateNameDictionary = new Dictionary<string, int>();
-			var skeletonName = GetSkeletonName(skeleton, instanceIndex);
-			var boneNamePrefix = instanceIndex != null ? $"{skeletonName}_" : "";
-			foreach (var bone in skeleton.Skeleton)
-			{
-				var boneName = bone.CleanedName;
-				if (duplicateNameDictionary.TryGetValue(boneName, out var count))
-				{
-					skeletonNodes.Add(new NodeBuilder($"{boneNamePrefix}{boneName}_{count:00}"));
-					duplicateNameDictionary[boneName] = ++count;
-				}
-				else
-				{
-					skeletonNodes.Add(new NodeBuilder($"{boneNamePrefix}{boneName}"));
-					duplicateNameDictionary.Add(boneName, 0);
-				}
-			}
-			if (objInstance != null)
-			{
-				var rootNode = GetRootSkeletonNodeTransformsFromObjectInstance(skeletonName, objInstance);
-				rootNode.AddNode(skeletonNodes[0]);
-			}
-			for (var i = 0; i < skeletonNodes.Count; i++)
-			{
-				var node = skeletonNodes[i];
-				var bone = skeleton.Skeleton[i];
-				bone.Children.ForEach(b => node.AddNode(skeletonNodes[b]));
-			}
-			if (parent != null && attachBoneName != null)
-			{
-				if (!_skeletons.TryGetValue(parent, out var parentSkeleton))
-				{
-					throw new InvalidOperationException($"Cannot attach child skeleton to parent: {parent}. It does not exist");
-				}
-				var attachBone = parentSkeleton
-					.Where(n => n.Name.Equals(attachBoneName, StringComparison.InvariantCultureIgnoreCase))
-					.SingleOrDefault();
-				if (attachBone == null)
-				{
-					throw new InvalidOperationException($"Cannot attach child skeleton to parent: {parent} at bone {attachBoneName}. Bone does not exist");
-				}
-				attachBone.AddNode(skeletonNodes[0]);
+        public List<NodeBuilder> AddNewSkeleton(SkeletonHierarchy skeleton, string parent = null, string attachBoneName = null, ObjInstance objInstance = null, int? instanceIndex = null)
+        {
+            var skeletonNodes = new List<NodeBuilder>();
+            var duplicateNameDictionary = new Dictionary<string, int>();
+            var skeletonName = GetSkeletonName(skeleton, instanceIndex);
+            var boneNamePrefix = instanceIndex != null ? $"{skeletonName}_" : "";
+            foreach (var bone in skeleton.Skeleton)
+            {
+                var boneName = bone.CleanedName;
+                if (duplicateNameDictionary.TryGetValue(boneName, out var count))
+                {
+                    skeletonNodes.Add(new NodeBuilder($"{boneNamePrefix}{boneName}_{count:00}"));
+                    duplicateNameDictionary[boneName] = ++count;
+                }
+                else
+                {
+                    skeletonNodes.Add(new NodeBuilder($"{boneNamePrefix}{boneName}"));
+                    duplicateNameDictionary.Add(boneName, 0);
+                }
+            }
+            if (objInstance != null)
+            {
+                var rootNode = GetRootSkeletonNodeTransformsFromObjectInstance(skeletonName, objInstance);
+                rootNode.AddNode(skeletonNodes[0]);
+            }
+            for (var i = 0; i < skeletonNodes.Count; i++)
+            {
+                var node = skeletonNodes[i];
+                var bone = skeleton.Skeleton[i];
+                bone.Children.ForEach(b => node.AddNode(skeletonNodes[b]));
+            }
+            if (parent != null && attachBoneName != null)
+            {
+                if (!_skeletons.TryGetValue(parent, out var parentSkeleton))
+                {
+                    throw new InvalidOperationException($"Cannot attach child skeleton to parent: {parent}. It does not exist");
+                }
+                var attachBone = parentSkeleton
+                    .Where(n => n.Name.Equals(attachBoneName, StringComparison.InvariantCultureIgnoreCase))
+                    .SingleOrDefault();
+                if (attachBone == null)
+                {
+                    throw new InvalidOperationException($"Cannot attach child skeleton to parent: {parent} at bone {attachBoneName}. Bone does not exist");
+                }
+                attachBone.AddNode(skeletonNodes[0]);
 
-				if (!_skeletonChildrenAttachBones.ContainsKey(parent))
-				{
-					_skeletonChildrenAttachBones.Add(parent, new List<(string, string)>());
-				}
-				_skeletonChildrenAttachBones[parent].Add((skeleton.ModelBase, attachBoneName));
-			}
-			_skeletons.Add(skeletonName, skeletonNodes);
-			return skeletonNodes;
-		}
+                if (!_skeletonChildrenAttachBones.ContainsKey(parent))
+                {
+                    _skeletonChildrenAttachBones.Add(parent, new List<(string, string)>());
+                }
+                _skeletonChildrenAttachBones[parent].Add((skeleton.ModelBase, attachBoneName));
+            }
+            _skeletons.Add(skeletonName, skeletonNodes);
+            return skeletonNodes;
+        }
 
-		public override void ClearExportData()
+        public override void ClearExportData()
         {
             _scene = null;
             _scene = new SceneBuilder();
@@ -769,12 +770,12 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 var newImageName = Path.GetFileNameWithoutExtension(convertedImagePath);
                 imageBuilder = ImageBuilder.From(new MemoryImage(convertedImagePath), newImageName);
 
-				// No support for animated textures, but in case the user wishes to add the frames
-				// somehow in post-process, add alpha to all frames of the animated texture
+                // No support for animated textures, but in case the user wishes to add the frames
+                // somehow in post-process, add alpha to all frames of the animated texture
                 if ((eqMaterial.BitmapInfoReference?.BitmapInfo.AnimationDelayMs ?? 0) > 0)
                 {
                     var animationFrameBitmaps = eqMaterial.BitmapInfoReference.BitmapInfo.BitmapNames;
-					for (var i = 1; i < animationFrameBitmaps.Count(); i++)
+                    for (var i = 1; i < animationFrameBitmaps.Count(); i++)
                     {
                         var frameImageFile = animationFrameBitmaps[i].GetExportFilename();
                         var frameImageFilePath = Path.Combine(textureImageFolder, frameImageFile);
@@ -832,47 +833,47 @@ namespace LanternExtractor.EQ.Wld.Exporters
         {
             var transformMatrix = Matrix4x4.CreateScale(instance.Scale)
                 * Matrix4x4.CreateFromYawPitchRoll(
-                    (float)(instance.Rotation.Z * Math.PI)/180f,
-                    (float)(instance.Rotation.X * Math.PI)/180f,
-                    (float)(instance.Rotation.Y * Math.PI)/180f
+                    (float)(-1 * instance.Rotation.Z * Math.PI) / 180f,
+                    (float)(instance.Rotation.X * Math.PI) / 180f,
+                    (float)(instance.Rotation.Y * Math.PI) / 180f
                 )
                 * Matrix4x4.CreateTranslation(instance.Position);
             return transformMatrix;
         }
 
-		private string GetSkeletonName(SkeletonHierarchy skeleton, int? instanceIndex = null)
+        private string GetSkeletonName(SkeletonHierarchy skeleton, int? instanceIndex = null)
         {
             if (skeleton == null) return null;
 
             return GetSkeletonName(skeleton.ModelBase, instanceIndex);
         }
 
-		private string GetSkeletonName(string skeletonModelBase, int? instanceIndex = null)
+        private string GetSkeletonName(string skeletonModelBase, int? instanceIndex = null)
         {
             if (skeletonModelBase == null) return null;
 
             if (instanceIndex != null)
             {
                 return $"{skeletonModelBase}_{instanceIndex:000}";
-			}
+            }
             return skeletonModelBase;
-		}
+        }
 
-		private NodeBuilder GetRootSkeletonNodeTransformsFromObjectInstance(string name, ObjInstance instance)
-		{
+        private NodeBuilder GetRootSkeletonNodeTransformsFromObjectInstance(string name, ObjInstance instance)
+        {
             var rootNode = new NodeBuilder(name);
-			var instanceTransformMatrix = CreateTransformMatrixForObjectInstance(instance);
+            var instanceTransformMatrix = CreateTransformMatrixForObjectInstance(instance);
             var zoneInstanceTransformMatrix = instanceTransformMatrix * CorrectedWorldMatrix;
             Matrix4x4.Decompose(zoneInstanceTransformMatrix, out var scale, out var rotation, out var translation);
-			rotation = Quaternion.Normalize(rotation);
-			rootNode.WithLocalScale(scale)
+            rotation = Quaternion.Normalize(rotation);
+            rootNode.WithLocalScale(scale)
                 .WithLocalRotation(rotation)
                 .WithLocalTranslation(translation);
 
             return rootNode;
-		}
+        }
 
-		private string GetMaterialName(Material eqMaterial)
+        private string GetMaterialName(Material eqMaterial)
         {
             return $"{MaterialList.GetMaterialPrefix(eqMaterial.ShaderType)}{eqMaterial.GetFirstBitmapNameWithoutExtension()}";
         }
@@ -902,13 +903,13 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 canExportVertexColors ? typeof(VertexColor1Texture1) : typeof(VertexTexture1),
                 isSkinned ? typeof(VertexJoints4) : typeof(VertexEmpty));
 
-            return (IMeshBuilder<MaterialBuilder>) Activator.CreateInstance(meshBuilderType, meshName);
+            return (IMeshBuilder<MaterialBuilder>)Activator.CreateInstance(meshBuilderType, meshName);
         }
 
-        private IDictionary<VertexPositionNormal,int> AddTriangleToMesh<TvG, TvM, TvS>(
+        private IDictionary<VertexPositionNormal, int> AddTriangleToMesh<TvG, TvM, TvS>(
             IPrimitiveBuilder primitive, WldMeshHelper meshHelper,
             int polygonIndex, bool canExportVertexColors, bool isSkinned,
-            int singularBoneIndex = -1, bool usesMobPieces = false, ObjInstance objectInstance = null)
+            int singularBoneIndex = -1, bool usesMobPieces = false, ObjInstance objectInstance = null, bool isZoneMesh = false)
                 where TvG : struct, IVertexGeometry
                 where TvM : struct, IVertexMaterial
                 where TvS : struct, IVertexSkinning
@@ -923,10 +924,11 @@ namespace LanternExtractor.EQ.Wld.Exporters
             var vertex0 = GetGltfVertex<TvG, TvM, TvS>(vertexPositions.v0, vertexNormals.v0, vertexUvs.v0, vertexColors.v0, isSkinned, boneIndexes.v0);
             var vertex1 = GetGltfVertex<TvG, TvM, TvS>(vertexPositions.v1, vertexNormals.v1, vertexUvs.v1, vertexColors.v1, isSkinned, boneIndexes.v1);
             var vertex2 = GetGltfVertex<TvG, TvM, TvS>(vertexPositions.v2, vertexNormals.v2, vertexUvs.v2, vertexColors.v2, isSkinned, boneIndexes.v2);
-            if (isSkinned)
+
+            // Always use clockwise rotation to offset the mirrored x axis
+            // If we're embedding in a zone or applying to a skinned model
+            if (objectInstance != null || isSkinned || isZoneMesh)
             {
-                // Normals come out wrong for skinned models unless we add the triangle
-                // vertices in reverse order
                 primitive.AddTriangle(vertex2, vertex1, vertex0);
             }
             else
@@ -952,36 +954,36 @@ namespace LanternExtractor.EQ.Wld.Exporters
         {
             var exportJoints = boneIndex > -1 && isSkinned;
             IVertexBuilder vertexBuilder;
-			if (color == null && !exportJoints)
-			{
-				vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexTexture1, VertexEmpty>
-					((position, normal), uv);
-			}
-			else if (color == null && exportJoints)
-			{
-				vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexTexture1, VertexJoints4>
-					((position, normal), uv, new VertexJoints4(boneIndex));
-			}
-			else if (color != null && !exportJoints)
-			{
-				vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexColor1Texture1, VertexEmpty>
-					((position, normal), (color.Value, uv));
-			}
-			else // (color != null && exportJoints)
-			{
-				vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexColor1Texture1, VertexJoints4>
-					((position, normal), (color.Value, uv), new VertexJoints4(boneIndex));
-			}
+            if (color == null && !exportJoints)
+            {
+                vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexTexture1, VertexEmpty>
+                    ((position, normal), uv);
+            }
+            else if (color == null && exportJoints)
+            {
+                vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexTexture1, VertexJoints4>
+                    ((position, normal), uv, new VertexJoints4(boneIndex));
+            }
+            else if (color != null && !exportJoints)
+            {
+                vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexColor1Texture1, VertexEmpty>
+                    ((position, normal), (color.Value, uv));
+            }
+            else // (color != null && exportJoints)
+            {
+                vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexColor1Texture1, VertexJoints4>
+                    ((position, normal), (color.Value, uv), new VertexJoints4(boneIndex));
+            }
 
-			return (VertexBuilder<TvG, TvM, TvS>)vertexBuilder;
+            return (VertexBuilder<TvG, TvM, TvS>)vertexBuilder;
         }
 
         private void AddAnimatedMeshMorphTargets(Mesh mesh, IMeshBuilder<MaterialBuilder> gltfMesh,
-            string meshName, Matrix4x4 transformMatrix, Dictionary<VertexPositionNormal, int> gltfVertexPositionToWldVertexIndex)
+            string meshName, Matrix4x4 transformMatrix, Dictionary<VertexPositionNormal, int> gltfVertexPositionToWldVertexIndex, bool mirrorAxis)
         {
             var frameTimes = new List<float>();
             var weights = new List<float>();
-            var frameDelay = mesh.AnimatedVerticesReference.MeshAnimatedVertices.Delay/1000f;
+            var frameDelay = mesh.AnimatedVerticesReference.MeshAnimatedVertices.Delay / 1000f;
 
             for (var frame = 0; frame < mesh.AnimatedVerticesReference.MeshAnimatedVertices.Frames.Count; frame++)
             {
@@ -992,7 +994,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 {
                     var vertexIndex = gltfVertexPositionToWldVertexIndex[vertexGeometry];
                     var wldVertexPositionForFrame = vertexPositionsForFrame[vertexIndex];
-                    var newPosition = (wldVertexPositionForFrame + mesh.Center).ToVector3(true);
+                    var newPosition = Vector3.Transform((wldVertexPositionForFrame + mesh.Center).ToVector3(true), mirrorAxis ? MirrorXAxisMatrix : Matrix4x4.Identity);
                     vertexGeometry.TryGetNormal(out var originalNormal);
                     morphTarget.SetVertex(vertexGeometry, new VertexPositionNormal(newPosition, originalNormal));
                 }
@@ -1005,7 +1007,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
             var instance = _scene.AddRigidMesh(gltfMesh, node);
             instance.Content.UseMorphing().SetValue(weights.ToArray());
-            var track = instance.Content.UseMorphing("Default");
+            var track = instance.Content.UseMorphing($"Default_{mesh.Name}");
             var morphTargetElements = new float[frameTimes.Count];
 
             for (var i = 0; i < frameTimes.Count; i++)
@@ -1018,42 +1020,42 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
         private NodeBuilder GetDoorAnimationNodeForOpenType(int openType, string meshName, Matrix4x4 transformMatrix)
         {
-			// For now, this is just windmill blades (105) and some other spinning
+            // For now, this is just windmill blades (105) and some other spinning
             // objects (100) like windmill shafts and akanon lights. The only other
             // doors that automatically move are a few traps in sol A and B
-			var node = new NodeBuilder(meshName);
+            var node = new NodeBuilder(meshName);
             node.LocalTransform = new AffineTransform(transformMatrix);
-			// Rotation part of the local transform is being lost with the animation -
-			// extract it out and multiply it with the animation steps
-			Matrix4x4.Decompose(transformMatrix, out _, out var baseRotation, out _);
-			switch (openType)
+            // Rotation part of the local transform is being lost with the animation -
+            // extract it out and multiply it with the animation steps
+            Matrix4x4.Decompose(transformMatrix, out _, out var baseRotation, out _);
+            switch (openType)
             {
                 case 100:
-					node.UseRotation("Default")
-	                    .WithPoint(0f, baseRotation)
-	                    .WithPoint(4.25f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitY, -(float)Math.PI))
-	                    .WithPoint(8.5f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitY, -(float)(2 * Math.PI)));
+                    node.UseRotation("Default")
+                        .WithPoint(0f, baseRotation)
+                        .WithPoint(4.25f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitY, -(float)Math.PI))
+                        .WithPoint(8.5f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitY, -(float)(2 * Math.PI)));
                     return node;
                 case 105:
-					node.UseRotation("Default")
-	                    .WithPoint(0f, baseRotation)
-	                    .WithPoint(4.25f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitZ, (float)Math.PI))
-	                    .WithPoint(8.5f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitZ, (float)(2 * Math.PI)));
+                    node.UseRotation("Default")
+                        .WithPoint(0f, baseRotation)
+                        .WithPoint(4.25f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitZ, (float)Math.PI))
+                        .WithPoint(8.5f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitZ, (float)(2 * Math.PI)));
                     return node;
                 default:
                     return node;
-			}
+            }
         }
-        private void ApplyBoneTransformation(NodeBuilder boneNode, DataTypes.BoneTransform boneTransform, 
+        private void ApplyBoneTransformation(NodeBuilder boneNode, DataTypes.BoneTransform boneTransform,
             string animationKey, int timeMs, bool staticPose)
         {
             var scaleVector = new Vector3(boneTransform.Scale);
             var rotationQuaternion = new Quaternion()
             {
-                X = (float)(boneTransform.Rotation.x * Math.PI)/180,
-                Y = (float)(boneTransform.Rotation.z * Math.PI)/180,
-                Z = (float)(boneTransform.Rotation.y * Math.PI * -1)/180,
-                W = (float)(boneTransform.Rotation.w * Math.PI)/180
+                X = (float)(boneTransform.Rotation.x * Math.PI) / 180,
+                Y = (float)(boneTransform.Rotation.z * Math.PI) / 180,
+                Z = (float)(boneTransform.Rotation.y * Math.PI * -1) / 180,
+                W = (float)(boneTransform.Rotation.w * Math.PI) / 180
             };
             rotationQuaternion = Quaternion.Normalize(rotationQuaternion);
             var translationVector = boneTransform.Translation.ToVector3(true);
@@ -1074,13 +1076,13 @@ namespace LanternExtractor.EQ.Wld.Exporters
             {
                 boneNode
                     .UseScale(animationDescription)
-                    .WithPoint(timeMs/1000f, scaleVector);
+                    .WithPoint(timeMs / 1000f, scaleVector);
                 boneNode
                     .UseRotation(animationDescription)
-                    .WithPoint(timeMs/1000f, rotationQuaternion);
+                    .WithPoint(timeMs / 1000f, rotationQuaternion);
                 boneNode
                     .UseTranslation(animationDescription)
-                    .WithPoint(timeMs/1000f, translationVector);
+                    .WithPoint(timeMs / 1000f, translationVector);
             }
         }
 
@@ -1103,7 +1105,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
         public ObjInstance(ObjectInstance objectInstanceFragment)
         {
             Name = objectInstanceFragment.ObjectName;
-            Position = objectInstanceFragment.Position.ToVector3(true);
+            Position = Vector3.Transform(objectInstanceFragment.Position.ToVector3(true), GltfWriter.MirrorXAxisMatrix);
             Rotation = objectInstanceFragment.Rotation.ToVector3();
             Scale = objectInstanceFragment.Scale.ToVector3();
             Colors = objectInstanceFragment.Colors;
@@ -1138,16 +1140,18 @@ namespace LanternExtractor.EQ.Wld.Exporters
         private readonly ISet<DataTypes.Polygon> _uniqueTriangles;
         private readonly IDictionary<int, Vector3> _wldVertexIndexToDuplicatedVertexNormals;
         private readonly TriangleVertexSetComparer _triangleSetComparer;
+        private readonly Matrix4x4 _transformMatrix;
 
-		private static readonly Vector4 DefaultVertexColor = new Vector4(0f, 0f, 0f, 1f); // Black
+        private static readonly Vector4 DefaultVertexColor = new Vector4(0f, 0f, 0f, 1f); // Black
 
-		public WldMeshHelper(Mesh wldMesh, bool separateTwoFacedTriangles)
+        public WldMeshHelper(Mesh wldMesh, bool separateTwoFacedTriangles, bool mirrorAxis = true)
         {
             _wldMesh = wldMesh;
             _separateTwoFacedTriangles = separateTwoFacedTriangles;
             _triangleSetComparer = new TriangleVertexSetComparer();
             _uniqueTriangles = new HashSet<DataTypes.Polygon>(_triangleSetComparer);
             _wldVertexIndexToDuplicatedVertexNormals = new Dictionary<int, Vector3>();
+            _transformMatrix = mirrorAxis ? Matrix4x4.CreateReflection(new Plane(1, 0, 0, 0)) : Matrix4x4.Identity;
         }
 
         public DataTypes.Polygon GetTriangle(int triangleIndex)
@@ -1157,74 +1161,73 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
         public (Vector3 v0, Vector3 v1, Vector3 v2) GetVertexPositions(DataTypes.Polygon triangle)
         {
-			(Vector3 v0, Vector3 v1, Vector3 v2) vertexPositions = (
-			(_wldMesh.Vertices[triangle.Vertex1] + _wldMesh.Center).ToVector3(true),
-			(_wldMesh.Vertices[triangle.Vertex2] + _wldMesh.Center).ToVector3(true),
-			(_wldMesh.Vertices[triangle.Vertex3] + _wldMesh.Center).ToVector3(true));
+            (Vector3 v0, Vector3 v1, Vector3 v2) vertexPositions = (
+            Vector3.Transform((_wldMesh.Vertices[triangle.Vertex1] + _wldMesh.Center).ToVector3(true), _transformMatrix),
+            Vector3.Transform((_wldMesh.Vertices[triangle.Vertex2] + _wldMesh.Center).ToVector3(true), _transformMatrix),
+            Vector3.Transform((_wldMesh.Vertices[triangle.Vertex3] + _wldMesh.Center).ToVector3(true), _transformMatrix));
 
             return vertexPositions;
-		}
+        }
 
         public (Vector3 v0, Vector3 v1, Vector3 v2) GetVertexNormals(DataTypes.Polygon triangle)
         {
-			if (_separateTwoFacedTriangles)
-			{
-				if (!_uniqueTriangles.Contains(triangle, _triangleSetComparer))
-				{
-					_uniqueTriangles.Add(triangle);
-				}
-				else
-				{
+            if (_separateTwoFacedTriangles)
+            {
+                if (!_uniqueTriangles.Contains(triangle, _triangleSetComparer))
+                {
+                    _uniqueTriangles.Add(triangle);
+                }
+                else
+                {
                     return GetDuplicateVertexNormalsForTriangle(triangle);
-				}
-			}
-
-			(Vector3 v0, Vector3 v1, Vector3 v2) vertexNormals = (
-			    Vector3.Normalize(_wldMesh.Normals[triangle.Vertex1].ToVector3(true)),
-	            Vector3.Normalize(_wldMesh.Normals[triangle.Vertex2].ToVector3(true)),
-	            Vector3.Normalize(_wldMesh.Normals[triangle.Vertex3].ToVector3(true)));
+                }
+            }
+            (Vector3 v0, Vector3 v1, Vector3 v2) vertexNormals = (
+                Vector3.Transform(Vector3.Normalize(_wldMesh.Normals[triangle.Vertex1].ToVector3(true)), _transformMatrix),
+                Vector3.Transform(Vector3.Normalize(_wldMesh.Normals[triangle.Vertex2].ToVector3(true)), _transformMatrix),
+                Vector3.Transform(Vector3.Normalize(_wldMesh.Normals[triangle.Vertex3].ToVector3(true)), _transformMatrix));
 
             return vertexNormals;
-		}
+        }
 
         public (Vector2 v0, Vector2 v1, Vector2 v2) GetVertexUvs(DataTypes.Polygon triangle)
         {
-			(Vector2 v0, Vector2 v1, Vector2 v2) vertexUvs = (
-			    _wldMesh.TextureUvCoordinates[triangle.Vertex1].ToVector2(true),
-				_wldMesh.TextureUvCoordinates[triangle.Vertex2].ToVector2(true),
-				_wldMesh.TextureUvCoordinates[triangle.Vertex3].ToVector2(true));
+            (Vector2 v0, Vector2 v1, Vector2 v2) vertexUvs = (
+                _wldMesh.TextureUvCoordinates[triangle.Vertex1].ToVector2(true),
+                _wldMesh.TextureUvCoordinates[triangle.Vertex2].ToVector2(true),
+                _wldMesh.TextureUvCoordinates[triangle.Vertex3].ToVector2(true));
 
             return vertexUvs;
-		}
+        }
 
         public (int v0, int v1, int v2) GetBoneIndexes(DataTypes.Polygon triangle, bool isSkinned, bool usesMobPieces, int singularBoneIndex)
         {
-			(int v0, int v1, int v2) boneIndexes = (singularBoneIndex, singularBoneIndex, singularBoneIndex);
-			if (isSkinned && (usesMobPieces || singularBoneIndex == -1))
-			{
-				var boneOffset = singularBoneIndex == -1 ? 0 : singularBoneIndex;
-				boneIndexes = (
-				    GetBoneIndexForVertex(triangle.Vertex1) + boneOffset,
-				    GetBoneIndexForVertex(triangle.Vertex2) + boneOffset,
-					GetBoneIndexForVertex(triangle.Vertex3) + boneOffset);
-			}
+            (int v0, int v1, int v2) boneIndexes = (singularBoneIndex, singularBoneIndex, singularBoneIndex);
+            if (isSkinned && (usesMobPieces || singularBoneIndex == -1))
+            {
+                var boneOffset = singularBoneIndex == -1 ? 0 : singularBoneIndex;
+                boneIndexes = (
+                    GetBoneIndexForVertex(triangle.Vertex1) + boneOffset,
+                    GetBoneIndexForVertex(triangle.Vertex2) + boneOffset,
+                    GetBoneIndexForVertex(triangle.Vertex3) + boneOffset);
+            }
 
             return boneIndexes;
-		}
+        }
 
-		public (Vector4? v0, Vector4? v1, Vector4? v2) GetVertexColorVectors(DataTypes.Polygon triangle, bool canExportVertexColors, ObjInstance objectInstance = null)
-		{
-			if (!canExportVertexColors) return (null, null, null);
+        public (Vector4? v0, Vector4? v1, Vector4? v2) GetVertexColorVectors(DataTypes.Polygon triangle, bool canExportVertexColors, ObjInstance objectInstance = null)
+        {
+            if (!canExportVertexColors) return (null, null, null);
 
-			var objInstanceColors = objectInstance?.Colors?.Colors ?? new List<WldColor>();
-			var meshColors = _wldMesh?.Colors ?? new List<WldColor>();
+            var objInstanceColors = objectInstance?.Colors?.Colors ?? new List<WldColor>();
+            var meshColors = _wldMesh?.Colors ?? new List<WldColor>();
 
-			var v0Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex1);
-			var v1Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex2);
-			var v2Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex3);
+            var v0Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex1);
+            var v1Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex2);
+            var v2Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex3);
 
-			return (v0Color, v1Color, v2Color);
-		}
+            return (v0Color, v1Color, v2Color);
+        }
 
         public void Reset()
         {
@@ -1232,75 +1235,75 @@ namespace LanternExtractor.EQ.Wld.Exporters
             _wldVertexIndexToDuplicatedVertexNormals.Clear();
         }
 
-		private (Vector3 v0, Vector3 v1, Vector3 v2) GetDuplicateVertexNormalsForTriangle(DataTypes.Polygon triangle)
+        private (Vector3 v0, Vector3 v1, Vector3 v2) GetDuplicateVertexNormalsForTriangle(DataTypes.Polygon triangle)
         {
             if (!_wldVertexIndexToDuplicatedVertexNormals.TryGetValue(triangle.Vertex1, out var v0Normal))
             {
                 v0Normal = Vector3.Normalize(-_wldMesh.Normals[triangle.Vertex1].ToVector3(true));
             }
-			if (!_wldVertexIndexToDuplicatedVertexNormals.TryGetValue(triangle.Vertex2, out var v1Normal))
-			{
-				v1Normal = Vector3.Normalize(-_wldMesh.Normals[triangle.Vertex2].ToVector3(true));
-			}
-			if (!_wldVertexIndexToDuplicatedVertexNormals.TryGetValue(triangle.Vertex3, out var v2Normal))
-			{
-				v2Normal = Vector3.Normalize(-_wldMesh.Normals[triangle.Vertex3].ToVector3(true));
-			}
+            if (!_wldVertexIndexToDuplicatedVertexNormals.TryGetValue(triangle.Vertex2, out var v1Normal))
+            {
+                v1Normal = Vector3.Normalize(-_wldMesh.Normals[triangle.Vertex2].ToVector3(true));
+            }
+            if (!_wldVertexIndexToDuplicatedVertexNormals.TryGetValue(triangle.Vertex3, out var v2Normal))
+            {
+                v2Normal = Vector3.Normalize(-_wldMesh.Normals[triangle.Vertex3].ToVector3(true));
+            }
 
             return (v0Normal, v1Normal, v2Normal);
-		}
+        }
 
-		private int GetBoneIndexForVertex(int vertexIndex)
-		{
-			foreach (var indexedMobVertexPiece in _wldMesh.MobPieces)
-			{
-				if (vertexIndex >= indexedMobVertexPiece.Value.Start &&
-					vertexIndex < indexedMobVertexPiece.Value.Start + indexedMobVertexPiece.Value.Count)
-				{
-					return indexedMobVertexPiece.Key;
-				}
-			}
-			return 0;
-		}
+        private int GetBoneIndexForVertex(int vertexIndex)
+        {
+            foreach (var indexedMobVertexPiece in _wldMesh.MobPieces)
+            {
+                if (vertexIndex >= indexedMobVertexPiece.Value.Start &&
+                    vertexIndex < indexedMobVertexPiece.Value.Start + indexedMobVertexPiece.Value.Count)
+                {
+                    return indexedMobVertexPiece.Key;
+                }
+            }
+            return 0;
+        }
 
-		private Vector4 CoalesceVertexColor(List<WldColor> meshColors, List<WldColor> objInstanceColors, int vertexIndex)
-		{
-			if (vertexIndex < objInstanceColors.Count)
-			{
-				return objInstanceColors[vertexIndex].ToVector4();
-			}
-			else if (vertexIndex < meshColors.Count)
-			{
-				return meshColors[vertexIndex].ToVector4();
-			}
-			else
-			{
-				return DefaultVertexColor;
-			}
-		}
-	}
+        private Vector4 CoalesceVertexColor(List<WldColor> meshColors, List<WldColor> objInstanceColors, int vertexIndex)
+        {
+            if (vertexIndex < objInstanceColors.Count)
+            {
+                return objInstanceColors[vertexIndex].ToVector4();
+            }
+            else if (vertexIndex < meshColors.Count)
+            {
+                return meshColors[vertexIndex].ToVector4();
+            }
+            else
+            {
+                return DefaultVertexColor;
+            }
+        }
+    }
 
-	public class TriangleVertexSetComparer : IEqualityComparer<DataTypes.Polygon>
-	{
-		public bool Equals(DataTypes.Polygon polyX, DataTypes.Polygon polyY)
-		{
-			var polyXSet = new HashSet<int>() { polyX.Vertex1, polyX.Vertex2, polyX.Vertex3 };
-			var polyYSet = new HashSet<int>() { polyY.Vertex1, polyY.Vertex2, polyY.Vertex3 };
+    public class TriangleVertexSetComparer : IEqualityComparer<DataTypes.Polygon>
+    {
+        public bool Equals(DataTypes.Polygon polyX, DataTypes.Polygon polyY)
+        {
+            var polyXSet = new HashSet<int>() { polyX.Vertex1, polyX.Vertex2, polyX.Vertex3 };
+            var polyYSet = new HashSet<int>() { polyY.Vertex1, polyY.Vertex2, polyY.Vertex3 };
 
             return polyXSet.SetEquals(polyYSet);
-		}
+        }
 
-		public int GetHashCode(DataTypes.Polygon poly)
-		{
+        public int GetHashCode(DataTypes.Polygon poly)
+        {
             var polyVertList1 = new List<int>() { poly.Vertex1, poly.Vertex2, poly.Vertex3 };
             polyVertList1.Sort();
 
-			unchecked
+            unchecked
             {
                 return 391 + polyVertList1.GetHashCode();
             }
-		}
-	}
+        }
+    }
 
     public struct UniqueLight
     {
@@ -1327,15 +1330,15 @@ namespace LanternExtractor.EQ.Wld.Exporters
         bool ShouldSkipMeshGenerationForMaterial(string materialName);
     }
 
-	static class ImageAlphaConverter
+    static class ImageAlphaConverter
     {
         public static string AddAlphaToImage(string filePath, ShaderType shaderType)
         {
             // var suffix = $"_{MaterialList.GetMaterialPrefix(shaderType).TrimEnd('_')}";
             var prefix = MaterialList.GetMaterialPrefix(shaderType);
-			// var newFileName = $"{Path.GetFileNameWithoutExtension(filePath)}{suffix}{Path.GetExtension(filePath)}";
-			var newFileName = $"{prefix}{Path.GetFileNameWithoutExtension(filePath)}{Path.GetExtension(filePath)}";
-			var newFilePath = Path.Combine(Path.GetDirectoryName(filePath), newFileName);
+            // var newFileName = $"{Path.GetFileNameWithoutExtension(filePath)}{suffix}{Path.GetExtension(filePath)}";
+            var newFileName = $"{prefix}{Path.GetFileNameWithoutExtension(filePath)}{Path.GetExtension(filePath)}";
+            var newFilePath = Path.Combine(Path.GetDirectoryName(filePath), newFileName);
 
             if (File.Exists(newFilePath)) return newFilePath;
 
@@ -1405,7 +1408,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
         public static Vector4 ToVector4(this Color color)
         {
-            return new Vector4(color.R/255.0f, color.G/255.0f, color.B/255.0f, color.A/255.0f);
+            return new Vector4(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
         }
     }
 

--- a/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
@@ -1158,11 +1158,11 @@ namespace LanternExtractor.EQ.Wld.Exporters
         public ObjInstance(Door door)
         {
             Name = door.Name;
-            Position = new Vector3(
+            Position = Vector3.Transform(new Vector3(
                 door.Position.Y,
                 door.Position.Z,
                 door.Position.X
-            );
+            ), GltfWriter.MirrorXAxisMatrix);
             Rotation = new Vector3(0f, door.Incline * 360f / 512f, -(float)(door.Heading * 360d / 512d));
             Scale = new Vector3(1f);
 

--- a/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
@@ -553,7 +553,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 foreach (var lightInstance in uniqueLightGroups)
                 {
                     var position = lightInstance.Position.ToVector3(swapYandZ: true);
-                    var translationMatrix = Matrix4x4.CreateTranslation(position) * CorrectedWorldMatrix;
+                    var translationMatrix = Matrix4x4.CreateTranslation(position) * CorrectedWorldMatrix * MirrorXAxisMatrix;
                     Matrix4x4.Decompose(translationMatrix, out _, out _, out var translation);
 					var lightName = lightInstance.LightReference?.LightSource?.Name;
 					var node = new NodeBuilder(lightName != null ? lightName.Split('_')[0] : "");

--- a/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
@@ -1022,7 +1022,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
         }
 
         private void AddAnimatedMeshMorphTargets(Mesh mesh, IMeshBuilder<MaterialBuilder> gltfMesh,
-            string meshName, Matrix4x4 transformMatrix, Dictionary<VertexPositionNormal, int> gltfVertexPositionToWldVertexIndex, bool mirrorAxis)
+            string meshName, Matrix4x4 transformMatrix, Dictionary<VertexPositionNormal, int> gltfVertexPositionToWldVertexIndex, bool mirrorXAxis)
         {
             var frameTimes = new List<float>();
             var weights = new List<float>();
@@ -1037,7 +1037,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 {
                     var vertexIndex = gltfVertexPositionToWldVertexIndex[vertexGeometry];
                     var wldVertexPositionForFrame = vertexPositionsForFrame[vertexIndex];
-                    var newPosition = Vector3.Transform((wldVertexPositionForFrame + mesh.Center).ToVector3(true), mirrorAxis ? MirrorXAxisMatrix : Matrix4x4.Identity);
+                    var newPosition = Vector3.Transform((wldVertexPositionForFrame + mesh.Center).ToVector3(true), mirrorXAxis ? MirrorXAxisMatrix : Matrix4x4.Identity);
                     vertexGeometry.TryGetNormal(out var originalNormal);
                     morphTarget.SetVertex(vertexGeometry, new VertexPositionNormal(newPosition, originalNormal));
                 }
@@ -1186,14 +1186,14 @@ namespace LanternExtractor.EQ.Wld.Exporters
         private readonly Matrix4x4 _transformMatrix;
 		private static readonly Vector4 DefaultVertexColor = new Vector4(0f, 0f, 0f, 1f); // Black
 
-		public WldMeshHelper(Mesh wldMesh, bool separateTwoFacedTriangles, bool mirrorAxis = true)
+		public WldMeshHelper(Mesh wldMesh, bool separateTwoFacedTriangles, bool mirrorXAxis = true)
         {
             _wldMesh = wldMesh;
             _separateTwoFacedTriangles = separateTwoFacedTriangles;
             _triangleSetComparer = new TriangleVertexSetComparer();
             _uniqueTriangles = new HashSet<DataTypes.Polygon>(_triangleSetComparer);
             _wldVertexIndexToDuplicatedVertexNormals = new Dictionary<int, Vector3>();
-            _transformMatrix = mirrorAxis ? Matrix4x4.CreateReflection(new Plane(1, 0, 0, 0)) : Matrix4x4.Identity;
+            _transformMatrix = mirrorXAxis ? Matrix4x4.CreateReflection(new Plane(1, 0, 0, 0)) : Matrix4x4.Identity;
         }
 
         public DataTypes.Polygon GetTriangle(int triangleIndex)

--- a/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/GltfWriter.cs
@@ -210,9 +210,9 @@ namespace LanternExtractor.EQ.Wld.Exporters
         private readonly Matrix4x4 CorrectedWorldMatrix;
         public static readonly Matrix4x4 MirrorXAxisMatrix = Matrix4x4.CreateReflection(new Plane(1, 0, 0, 0));
         private static readonly Matrix4x4 CorrectedSingularActorMatrix = Matrix4x4.CreateReflection(new Plane(0, 0, 1, 0));
-        #endregion
+		#endregion
 
-        private SceneBuilder _scene;
+		private SceneBuilder _scene;
         private IMeshBuilder<MaterialBuilder> _combinedMeshBuilder;
         private ISet<string> _meshMaterialsToSkip;
         private IDictionary<string, IMeshBuilder<MaterialBuilder>> _sharedMeshes;
@@ -239,13 +239,13 @@ namespace LanternExtractor.EQ.Wld.Exporters
         public override void AddFragmentData(WldFragment fragment)
         {
             AddFragmentData(
-                mesh: (Mesh)fragment,
-                generationMode: ModelGenerationMode.Separate);
+                mesh:(Mesh)fragment, 
+                generationMode:ModelGenerationMode.Separate );
         }
 
-        public void AddFragmentData(Mesh mesh, SkeletonHierarchy skeleton, int singularBoneIndex = -1,
-            ICharacterModel characterModel = null, string parentSkeletonName = null, string parentSkeletonAttachBoneName = null,
-            string meshNameOverride = null, bool usesMobPieces = false)
+        public void AddFragmentData(Mesh mesh, SkeletonHierarchy skeleton, int singularBoneIndex = -1, 
+            ICharacterModel characterModel = null, string parentSkeletonName = null, string parentSkeletonAttachBoneName = null, 
+            string meshNameOverride = null, bool usesMobPieces = false )
         {
             if (!_skeletons.ContainsKey(skeleton.ModelBase))
             {
@@ -253,10 +253,10 @@ namespace LanternExtractor.EQ.Wld.Exporters
             }
 
             AddFragmentData(
-                mesh: mesh,
-                generationMode: ModelGenerationMode.Combine,
-                isSkinned: true,
-                meshNameOverride: meshNameOverride,
+                mesh: mesh, 
+                generationMode: ModelGenerationMode.Combine, 
+                isSkinned: true, 
+                meshNameOverride: meshNameOverride, 
                 singularBoneIndex: singularBoneIndex,
                 usesMobPieces: usesMobPieces,
                 characterModel: characterModel);
@@ -293,26 +293,26 @@ namespace LanternExtractor.EQ.Wld.Exporters
         }
 
         public void AddFragmentData(
-            Mesh mesh,
-            ModelGenerationMode generationMode,
-            bool isSkinned = false,
+            Mesh mesh, 
+            ModelGenerationMode generationMode, 
+            bool isSkinned = false, 
             string meshNameOverride = null,
-            int singularBoneIndex = -1,
-            ObjInstance objectInstance = null,
+            int singularBoneIndex = -1, 
+            ObjInstance objectInstance = null, 
             int instanceIndex = 0,
             bool isZoneMesh = false,
             bool usesMobPieces = false,
             ICharacterModel characterModel = null)
         {
             var meshName = meshNameOverride ?? FragmentNameCleaner.CleanName(mesh);
-            var transformMatrix = objectInstance == null ? Matrix4x4.Identity : CreateTransformMatrixForObjectInstance(objectInstance);
-            transformMatrix = transformMatrix *= isZoneMesh ? CorrectedWorldMatrix : Matrix4x4.Identity;
+			var transformMatrix = objectInstance == null ? Matrix4x4.Identity : CreateTransformMatrixForObjectInstance(objectInstance);
+			transformMatrix = transformMatrix *= isZoneMesh ? CorrectedWorldMatrix : Matrix4x4.Identity;
 
-            var canExportVertexColors = _exportVertexColors &&
+			var canExportVertexColors = _exportVertexColors &&
                 ((objectInstance?.Colors?.Colors != null && objectInstance.Colors.Colors.Any())
                 || (mesh?.Colors != null && mesh.Colors.Any()));
-
-            if (mesh.AnimatedVerticesReference == null && !canExportVertexColors && objectInstance != null &&
+            
+            if (mesh.AnimatedVerticesReference == null && !canExportVertexColors && objectInstance != null && 
                 _sharedMeshes.TryGetValue(meshName, out var existingMesh))
             {
                 if (generationMode == ModelGenerationMode.Separate)
@@ -344,7 +344,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
             // Keeping track of vertex indexes for each vertex position in case it's an
             // animated mesh so we can create morph targets later
             var gltfVertexPositionToWldVertexIndex = new Dictionary<VertexPositionNormal, int>();
-
+            
             var polygonIndex = 0;
             var meshHelper = new WldMeshHelper(mesh, _separateTwoFacedTriangles, isZoneMesh);
             foreach (var materialGroup in mesh.MaterialGroups)
@@ -355,14 +355,14 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 {
                     if (characterModel.TryGetMaterialVariation(material.GetFirstBitmapNameWithoutExtension(), out var variationIndex, out var color))
                     {
-                        var alternateSkins = mesh.MaterialList.GetMaterialVariants(material, _logger);
-                        if (alternateSkins.Any() && alternateSkins.Count() > variationIndex && alternateSkins.ElementAt(variationIndex) != null)
-                        {
-                            material = alternateSkins[variationIndex];
-                        }
+						var alternateSkins = mesh.MaterialList.GetMaterialVariants(material, _logger);
+						if (alternateSkins.Any() && alternateSkins.Count() > variationIndex && alternateSkins.ElementAt(variationIndex) != null)
+						{
+							material = alternateSkins[variationIndex];
+						}
                     }
-                    baseColor = color;
-                }
+					baseColor = color;
+				}
                 var materialName = GetMaterialName(material);
 
                 if (_meshMaterialsToSkip.Contains(materialName) || (characterModel != null && characterModel.ShouldSkipMeshGenerationForMaterial(materialName)))
@@ -422,13 +422,13 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 else if (AnimatedDoorObjectOpenTypes.TryGetValue(meshName, out var openType))
                 {
                     var node = GetDoorAnimationNodeForOpenType(openType, meshName, transformMatrix);
-                    _scene.AddRigidMesh(gltfMesh, node);
-                }
+					_scene.AddRigidMesh(gltfMesh, node);
+				}
                 else
                 {
                     _scene.AddRigidMesh(gltfMesh, new AffineTransform(transformMatrix));
                     _sharedMeshes[meshName] = gltfMesh;
-                }
+                }              
             }
         }
 
@@ -446,7 +446,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
             var poseArray = isCharacterAnimation
                 ? skeleton.Animations[DefaultModelPoseAnimationKey].TracksCleanedStripped
                 : skeleton.Animations[DefaultModelPoseAnimationKey].TracksCleaned;
-
+            
             if (poseArray == null) return;
             var hasChildren = _skeletonChildrenAttachBones.TryGetValue(skeleton.ModelBase, out var skeletonChildrenAttachBones);
             for (var i = 0; i < skeleton.Skeleton.Count; i++)
@@ -523,19 +523,19 @@ namespace LanternExtractor.EQ.Wld.Exporters
                     var position = lightInstance.Position.ToVector3(swapYandZ: true);
                     var translationMatrix = Matrix4x4.CreateTranslation(position) * CorrectedWorldMatrix;
                     Matrix4x4.Decompose(translationMatrix, out _, out _, out var translation);
-                    var lightName = lightInstance.LightReference?.LightSource?.Name;
-                    var node = new NodeBuilder(lightName != null ? lightName.Split('_')[0] : "");
-                    // node.WithTranslation(translation) makes VS complain for some reason
-                    node.LocalTransform = node.LocalTransform.WithTranslation(translation);
-                    _scene.AddLight(light, node);
+					var lightName = lightInstance.LightReference?.LightSource?.Name;
+					var node = new NodeBuilder(lightName != null ? lightName.Split('_')[0] : "");
+					// node.WithTranslation(translation) makes VS complain for some reason
+					node.LocalTransform = node.LocalTransform.WithTranslation(translation);
+					_scene.AddLight(light, node);
                 }
             }
-        }
+		}
 
         public void AddCombinedMeshToScene(
-            bool isZoneMesh = false,
-            string meshName = null,
-            string skeletonModelBase = null,
+            bool isZoneMesh = false, 
+            string meshName = null, 
+            string skeletonModelBase = null, 
             ObjInstance objectInstance = null,
             int? instanceIndex = null)
         {
@@ -550,8 +550,8 @@ namespace LanternExtractor.EQ.Wld.Exporters
             }
             if (combinedMesh == null) return;
 
-            var skeletonName = GetSkeletonName(skeletonModelBase, instanceIndex);
-
+			var skeletonName = GetSkeletonName(skeletonModelBase, instanceIndex);
+			
             var worldTransformMatrix = Matrix4x4.Identity;
             if (objectInstance != null && skeletonName == null)
             {
@@ -585,7 +585,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
                     worldTransformMatrix = skeletonNodes[0].Parent.WorldMatrix;
                 }
 
-                _scene.AddSkinnedMesh(combinedMesh, worldTransformMatrix, skeletonNodes.ToArray());
+                _scene.AddSkinnedMesh(combinedMesh, worldTransformMatrix, skeletonNodes.ToArray());       
             }
 
             if (meshName != null && !_sharedMeshes.ContainsKey(meshName))
@@ -604,7 +604,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
         {
             AddCombinedMeshToScene(false, null, skeletonModelBase);
 
-            var outputFilePath = FixFilePath(fileName);
+			var outputFilePath = FixFilePath(fileName);
             var model = _scene.ToGltf2();
 
             if (_exportFormat == GltfExportFormat.GlTF)
@@ -639,7 +639,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
                             return $"Textures/{Path.GetFileName(imageSourcePath)}";
                         }
                     };
-                    model.SaveGLTF(outputFilePath, writeSettings);
+					model.SaveGLTF(outputFilePath, writeSettings);
                 }
             }
             else // Glb
@@ -653,63 +653,63 @@ namespace LanternExtractor.EQ.Wld.Exporters
             }
         }
 
-        public List<NodeBuilder> AddNewSkeleton(SkeletonHierarchy skeleton, string parent = null, string attachBoneName = null, ObjInstance objInstance = null, int? instanceIndex = null)
-        {
-            var skeletonNodes = new List<NodeBuilder>();
-            var duplicateNameDictionary = new Dictionary<string, int>();
-            var skeletonName = GetSkeletonName(skeleton, instanceIndex);
-            var boneNamePrefix = instanceIndex != null ? $"{skeletonName}_" : "";
-            foreach (var bone in skeleton.Skeleton)
-            {
-                var boneName = bone.CleanedName;
-                if (duplicateNameDictionary.TryGetValue(boneName, out var count))
-                {
-                    skeletonNodes.Add(new NodeBuilder($"{boneNamePrefix}{boneName}_{count:00}"));
-                    duplicateNameDictionary[boneName] = ++count;
-                }
-                else
-                {
-                    skeletonNodes.Add(new NodeBuilder($"{boneNamePrefix}{boneName}"));
-                    duplicateNameDictionary.Add(boneName, 0);
-                }
-            }
-            if (objInstance != null)
-            {
-                var rootNode = GetRootSkeletonNodeTransformsFromObjectInstance(skeletonName, objInstance);
-                rootNode.AddNode(skeletonNodes[0]);
-            }
-            for (var i = 0; i < skeletonNodes.Count; i++)
-            {
-                var node = skeletonNodes[i];
-                var bone = skeleton.Skeleton[i];
-                bone.Children.ForEach(b => node.AddNode(skeletonNodes[b]));
-            }
-            if (parent != null && attachBoneName != null)
-            {
-                if (!_skeletons.TryGetValue(parent, out var parentSkeleton))
-                {
-                    throw new InvalidOperationException($"Cannot attach child skeleton to parent: {parent}. It does not exist");
-                }
-                var attachBone = parentSkeleton
-                    .Where(n => n.Name.Equals(attachBoneName, StringComparison.InvariantCultureIgnoreCase))
-                    .SingleOrDefault();
-                if (attachBone == null)
-                {
-                    throw new InvalidOperationException($"Cannot attach child skeleton to parent: {parent} at bone {attachBoneName}. Bone does not exist");
-                }
-                attachBone.AddNode(skeletonNodes[0]);
+		public List<NodeBuilder> AddNewSkeleton(SkeletonHierarchy skeleton, string parent = null, string attachBoneName = null, ObjInstance objInstance = null, int? instanceIndex = null)
+		{
+			var skeletonNodes = new List<NodeBuilder>();
+			var duplicateNameDictionary = new Dictionary<string, int>();
+			var skeletonName = GetSkeletonName(skeleton, instanceIndex);
+			var boneNamePrefix = instanceIndex != null ? $"{skeletonName}_" : "";
+			foreach (var bone in skeleton.Skeleton)
+			{
+				var boneName = bone.CleanedName;
+				if (duplicateNameDictionary.TryGetValue(boneName, out var count))
+				{
+					skeletonNodes.Add(new NodeBuilder($"{boneNamePrefix}{boneName}_{count:00}"));
+					duplicateNameDictionary[boneName] = ++count;
+				}
+				else
+				{
+					skeletonNodes.Add(new NodeBuilder($"{boneNamePrefix}{boneName}"));
+					duplicateNameDictionary.Add(boneName, 0);
+				}
+			}
+			if (objInstance != null)
+			{
+				var rootNode = GetRootSkeletonNodeTransformsFromObjectInstance(skeletonName, objInstance);
+				rootNode.AddNode(skeletonNodes[0]);
+			}
+			for (var i = 0; i < skeletonNodes.Count; i++)
+			{
+				var node = skeletonNodes[i];
+				var bone = skeleton.Skeleton[i];
+				bone.Children.ForEach(b => node.AddNode(skeletonNodes[b]));
+			}
+			if (parent != null && attachBoneName != null)
+			{
+				if (!_skeletons.TryGetValue(parent, out var parentSkeleton))
+				{
+					throw new InvalidOperationException($"Cannot attach child skeleton to parent: {parent}. It does not exist");
+				}
+				var attachBone = parentSkeleton
+					.Where(n => n.Name.Equals(attachBoneName, StringComparison.InvariantCultureIgnoreCase))
+					.SingleOrDefault();
+				if (attachBone == null)
+				{
+					throw new InvalidOperationException($"Cannot attach child skeleton to parent: {parent} at bone {attachBoneName}. Bone does not exist");
+				}
+				attachBone.AddNode(skeletonNodes[0]);
 
-                if (!_skeletonChildrenAttachBones.ContainsKey(parent))
-                {
-                    _skeletonChildrenAttachBones.Add(parent, new List<(string, string)>());
-                }
-                _skeletonChildrenAttachBones[parent].Add((skeleton.ModelBase, attachBoneName));
-            }
-            _skeletons.Add(skeletonName, skeletonNodes);
-            return skeletonNodes;
-        }
+				if (!_skeletonChildrenAttachBones.ContainsKey(parent))
+				{
+					_skeletonChildrenAttachBones.Add(parent, new List<(string, string)>());
+				}
+				_skeletonChildrenAttachBones[parent].Add((skeleton.ModelBase, attachBoneName));
+			}
+			_skeletons.Add(skeletonName, skeletonNodes);
+			return skeletonNodes;
+		}
 
-        public override void ClearExportData()
+		public override void ClearExportData()
         {
             _scene = null;
             _scene = new SceneBuilder();
@@ -770,12 +770,12 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 var newImageName = Path.GetFileNameWithoutExtension(convertedImagePath);
                 imageBuilder = ImageBuilder.From(new MemoryImage(convertedImagePath), newImageName);
 
-                // No support for animated textures, but in case the user wishes to add the frames
-                // somehow in post-process, add alpha to all frames of the animated texture
+				// No support for animated textures, but in case the user wishes to add the frames
+				// somehow in post-process, add alpha to all frames of the animated texture
                 if ((eqMaterial.BitmapInfoReference?.BitmapInfo.AnimationDelayMs ?? 0) > 0)
                 {
                     var animationFrameBitmaps = eqMaterial.BitmapInfoReference.BitmapInfo.BitmapNames;
-                    for (var i = 1; i < animationFrameBitmaps.Count(); i++)
+					for (var i = 1; i < animationFrameBitmaps.Count(); i++)
                     {
                         var frameImageFile = animationFrameBitmaps[i].GetExportFilename();
                         var frameImageFilePath = Path.Combine(textureImageFolder, frameImageFile);
@@ -833,47 +833,47 @@ namespace LanternExtractor.EQ.Wld.Exporters
         {
             var transformMatrix = Matrix4x4.CreateScale(instance.Scale)
                 * Matrix4x4.CreateFromYawPitchRoll(
-                    (float)(-1 * instance.Rotation.Z * Math.PI) / 180f,
-                    (float)(instance.Rotation.X * Math.PI) / 180f,
-                    (float)(instance.Rotation.Y * Math.PI) / 180f
+                    (float)(-1 * instance.Rotation.Z * Math.PI)/180f,
+                    (float)(instance.Rotation.X * Math.PI)/180f,
+                    (float)(instance.Rotation.Y * Math.PI)/180f
                 )
                 * Matrix4x4.CreateTranslation(instance.Position);
             return transformMatrix;
         }
 
-        private string GetSkeletonName(SkeletonHierarchy skeleton, int? instanceIndex = null)
+		private string GetSkeletonName(SkeletonHierarchy skeleton, int? instanceIndex = null)
         {
             if (skeleton == null) return null;
 
             return GetSkeletonName(skeleton.ModelBase, instanceIndex);
         }
 
-        private string GetSkeletonName(string skeletonModelBase, int? instanceIndex = null)
+		private string GetSkeletonName(string skeletonModelBase, int? instanceIndex = null)
         {
             if (skeletonModelBase == null) return null;
 
             if (instanceIndex != null)
             {
                 return $"{skeletonModelBase}_{instanceIndex:000}";
-            }
+			}
             return skeletonModelBase;
-        }
+		}
 
-        private NodeBuilder GetRootSkeletonNodeTransformsFromObjectInstance(string name, ObjInstance instance)
-        {
+		private NodeBuilder GetRootSkeletonNodeTransformsFromObjectInstance(string name, ObjInstance instance)
+		{
             var rootNode = new NodeBuilder(name);
-            var instanceTransformMatrix = CreateTransformMatrixForObjectInstance(instance);
+			var instanceTransformMatrix = CreateTransformMatrixForObjectInstance(instance);
             var zoneInstanceTransformMatrix = instanceTransformMatrix * CorrectedWorldMatrix;
             Matrix4x4.Decompose(zoneInstanceTransformMatrix, out var scale, out var rotation, out var translation);
-            rotation = Quaternion.Normalize(rotation);
-            rootNode.WithLocalScale(scale)
+			rotation = Quaternion.Normalize(rotation);
+			rootNode.WithLocalScale(scale)
                 .WithLocalRotation(rotation)
                 .WithLocalTranslation(translation);
 
             return rootNode;
-        }
+		}
 
-        private string GetMaterialName(Material eqMaterial)
+		private string GetMaterialName(Material eqMaterial)
         {
             return $"{MaterialList.GetMaterialPrefix(eqMaterial.ShaderType)}{eqMaterial.GetFirstBitmapNameWithoutExtension()}";
         }
@@ -903,10 +903,10 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 canExportVertexColors ? typeof(VertexColor1Texture1) : typeof(VertexTexture1),
                 isSkinned ? typeof(VertexJoints4) : typeof(VertexEmpty));
 
-            return (IMeshBuilder<MaterialBuilder>)Activator.CreateInstance(meshBuilderType, meshName);
+            return (IMeshBuilder<MaterialBuilder>) Activator.CreateInstance(meshBuilderType, meshName);
         }
 
-        private IDictionary<VertexPositionNormal, int> AddTriangleToMesh<TvG, TvM, TvS>(
+        private IDictionary<VertexPositionNormal,int> AddTriangleToMesh<TvG, TvM, TvS>(
             IPrimitiveBuilder primitive, WldMeshHelper meshHelper,
             int polygonIndex, bool canExportVertexColors, bool isSkinned,
             int singularBoneIndex = -1, bool usesMobPieces = false, ObjInstance objectInstance = null, bool isZoneMesh = false)
@@ -954,28 +954,28 @@ namespace LanternExtractor.EQ.Wld.Exporters
         {
             var exportJoints = boneIndex > -1 && isSkinned;
             IVertexBuilder vertexBuilder;
-            if (color == null && !exportJoints)
-            {
-                vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexTexture1, VertexEmpty>
-                    ((position, normal), uv);
-            }
-            else if (color == null && exportJoints)
-            {
-                vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexTexture1, VertexJoints4>
-                    ((position, normal), uv, new VertexJoints4(boneIndex));
-            }
-            else if (color != null && !exportJoints)
-            {
-                vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexColor1Texture1, VertexEmpty>
-                    ((position, normal), (color.Value, uv));
-            }
-            else // (color != null && exportJoints)
-            {
-                vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexColor1Texture1, VertexJoints4>
-                    ((position, normal), (color.Value, uv), new VertexJoints4(boneIndex));
-            }
+			if (color == null && !exportJoints)
+			{
+				vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexTexture1, VertexEmpty>
+					((position, normal), uv);
+			}
+			else if (color == null && exportJoints)
+			{
+				vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexTexture1, VertexJoints4>
+					((position, normal), uv, new VertexJoints4(boneIndex));
+			}
+			else if (color != null && !exportJoints)
+			{
+				vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexColor1Texture1, VertexEmpty>
+					((position, normal), (color.Value, uv));
+			}
+			else // (color != null && exportJoints)
+			{
+				vertexBuilder = new VertexBuilder<VertexPositionNormal, VertexColor1Texture1, VertexJoints4>
+					((position, normal), (color.Value, uv), new VertexJoints4(boneIndex));
+			}
 
-            return (VertexBuilder<TvG, TvM, TvS>)vertexBuilder;
+			return (VertexBuilder<TvG, TvM, TvS>)vertexBuilder;
         }
 
         private void AddAnimatedMeshMorphTargets(Mesh mesh, IMeshBuilder<MaterialBuilder> gltfMesh,
@@ -983,7 +983,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
         {
             var frameTimes = new List<float>();
             var weights = new List<float>();
-            var frameDelay = mesh.AnimatedVerticesReference.MeshAnimatedVertices.Delay / 1000f;
+            var frameDelay = mesh.AnimatedVerticesReference.MeshAnimatedVertices.Delay/1000f;
 
             for (var frame = 0; frame < mesh.AnimatedVerticesReference.MeshAnimatedVertices.Frames.Count; frame++)
             {
@@ -1020,42 +1020,42 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
         private NodeBuilder GetDoorAnimationNodeForOpenType(int openType, string meshName, Matrix4x4 transformMatrix)
         {
-            // For now, this is just windmill blades (105) and some other spinning
+			// For now, this is just windmill blades (105) and some other spinning
             // objects (100) like windmill shafts and akanon lights. The only other
             // doors that automatically move are a few traps in sol A and B
-            var node = new NodeBuilder(meshName);
+			var node = new NodeBuilder(meshName);
             node.LocalTransform = new AffineTransform(transformMatrix);
-            // Rotation part of the local transform is being lost with the animation -
-            // extract it out and multiply it with the animation steps
-            Matrix4x4.Decompose(transformMatrix, out _, out var baseRotation, out _);
-            switch (openType)
+			// Rotation part of the local transform is being lost with the animation -
+			// extract it out and multiply it with the animation steps
+			Matrix4x4.Decompose(transformMatrix, out _, out var baseRotation, out _);
+			switch (openType)
             {
                 case 100:
-                    node.UseRotation("Default")
-                        .WithPoint(0f, baseRotation)
-                        .WithPoint(4.25f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitY, -(float)Math.PI))
-                        .WithPoint(8.5f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitY, -(float)(2 * Math.PI)));
+					node.UseRotation("Default")
+	                    .WithPoint(0f, baseRotation)
+	                    .WithPoint(4.25f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitY, -(float)Math.PI))
+	                    .WithPoint(8.5f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitY, -(float)(2 * Math.PI)));
                     return node;
                 case 105:
-                    node.UseRotation("Default")
-                        .WithPoint(0f, baseRotation)
-                        .WithPoint(4.25f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitZ, (float)Math.PI))
-                        .WithPoint(8.5f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitZ, (float)(2 * Math.PI)));
+					node.UseRotation("Default")
+	                    .WithPoint(0f, baseRotation)
+	                    .WithPoint(4.25f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitZ, (float)Math.PI))
+	                    .WithPoint(8.5f, baseRotation * Quaternion.CreateFromAxisAngle(Vector3.UnitZ, (float)(2 * Math.PI)));
                     return node;
                 default:
                     return node;
-            }
+			}
         }
-        private void ApplyBoneTransformation(NodeBuilder boneNode, DataTypes.BoneTransform boneTransform,
+        private void ApplyBoneTransformation(NodeBuilder boneNode, DataTypes.BoneTransform boneTransform, 
             string animationKey, int timeMs, bool staticPose)
         {
             var scaleVector = new Vector3(boneTransform.Scale);
             var rotationQuaternion = new Quaternion()
             {
-                X = (float)(boneTransform.Rotation.x * Math.PI) / 180,
-                Y = (float)(boneTransform.Rotation.z * Math.PI) / 180,
-                Z = (float)(boneTransform.Rotation.y * Math.PI * -1) / 180,
-                W = (float)(boneTransform.Rotation.w * Math.PI) / 180
+                X = (float)(boneTransform.Rotation.x * Math.PI)/180,
+                Y = (float)(boneTransform.Rotation.z * Math.PI)/180,
+                Z = (float)(boneTransform.Rotation.y * Math.PI * -1)/180,
+                W = (float)(boneTransform.Rotation.w * Math.PI)/180
             };
             rotationQuaternion = Quaternion.Normalize(rotationQuaternion);
             var translationVector = boneTransform.Translation.ToVector3(true);
@@ -1076,13 +1076,13 @@ namespace LanternExtractor.EQ.Wld.Exporters
             {
                 boneNode
                     .UseScale(animationDescription)
-                    .WithPoint(timeMs / 1000f, scaleVector);
+                    .WithPoint(timeMs/1000f, scaleVector);
                 boneNode
                     .UseRotation(animationDescription)
-                    .WithPoint(timeMs / 1000f, rotationQuaternion);
+                    .WithPoint(timeMs/1000f, rotationQuaternion);
                 boneNode
                     .UseTranslation(animationDescription)
-                    .WithPoint(timeMs / 1000f, translationVector);
+                    .WithPoint(timeMs/1000f, translationVector);
             }
         }
 
@@ -1141,10 +1141,9 @@ namespace LanternExtractor.EQ.Wld.Exporters
         private readonly IDictionary<int, Vector3> _wldVertexIndexToDuplicatedVertexNormals;
         private readonly TriangleVertexSetComparer _triangleSetComparer;
         private readonly Matrix4x4 _transformMatrix;
+		private static readonly Vector4 DefaultVertexColor = new Vector4(0f, 0f, 0f, 1f); // Black
 
-        private static readonly Vector4 DefaultVertexColor = new Vector4(0f, 0f, 0f, 1f); // Black
-
-        public WldMeshHelper(Mesh wldMesh, bool separateTwoFacedTriangles, bool mirrorAxis = true)
+		public WldMeshHelper(Mesh wldMesh, bool separateTwoFacedTriangles, bool mirrorAxis = true)
         {
             _wldMesh = wldMesh;
             _separateTwoFacedTriangles = separateTwoFacedTriangles;
@@ -1161,73 +1160,74 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
         public (Vector3 v0, Vector3 v1, Vector3 v2) GetVertexPositions(DataTypes.Polygon triangle)
         {
-            (Vector3 v0, Vector3 v1, Vector3 v2) vertexPositions = (
-            Vector3.Transform((_wldMesh.Vertices[triangle.Vertex1] + _wldMesh.Center).ToVector3(true), _transformMatrix),
+			(Vector3 v0, Vector3 v1, Vector3 v2) vertexPositions = (
+			Vector3.Transform((_wldMesh.Vertices[triangle.Vertex1] + _wldMesh.Center).ToVector3(true), _transformMatrix),
             Vector3.Transform((_wldMesh.Vertices[triangle.Vertex2] + _wldMesh.Center).ToVector3(true), _transformMatrix),
             Vector3.Transform((_wldMesh.Vertices[triangle.Vertex3] + _wldMesh.Center).ToVector3(true), _transformMatrix));
 
             return vertexPositions;
-        }
+		}
 
         public (Vector3 v0, Vector3 v1, Vector3 v2) GetVertexNormals(DataTypes.Polygon triangle)
         {
-            if (_separateTwoFacedTriangles)
-            {
-                if (!_uniqueTriangles.Contains(triangle, _triangleSetComparer))
-                {
-                    _uniqueTriangles.Add(triangle);
-                }
-                else
-                {
+			if (_separateTwoFacedTriangles)
+			{
+				if (!_uniqueTriangles.Contains(triangle, _triangleSetComparer))
+				{
+					_uniqueTriangles.Add(triangle);
+				}
+				else
+				{
                     return GetDuplicateVertexNormalsForTriangle(triangle);
-                }
-            }
-            (Vector3 v0, Vector3 v1, Vector3 v2) vertexNormals = (
-                Vector3.Transform(Vector3.Normalize(_wldMesh.Normals[triangle.Vertex1].ToVector3(true)), _transformMatrix),
+				}
+			}
+
+			(Vector3 v0, Vector3 v1, Vector3 v2) vertexNormals = (
+			    Vector3.Transform(Vector3.Normalize(_wldMesh.Normals[triangle.Vertex1].ToVector3(true)), _transformMatrix),
                 Vector3.Transform(Vector3.Normalize(_wldMesh.Normals[triangle.Vertex2].ToVector3(true)), _transformMatrix),
                 Vector3.Transform(Vector3.Normalize(_wldMesh.Normals[triangle.Vertex3].ToVector3(true)), _transformMatrix));
 
             return vertexNormals;
-        }
+		}
 
         public (Vector2 v0, Vector2 v1, Vector2 v2) GetVertexUvs(DataTypes.Polygon triangle)
         {
-            (Vector2 v0, Vector2 v1, Vector2 v2) vertexUvs = (
-                _wldMesh.TextureUvCoordinates[triangle.Vertex1].ToVector2(true),
-                _wldMesh.TextureUvCoordinates[triangle.Vertex2].ToVector2(true),
-                _wldMesh.TextureUvCoordinates[triangle.Vertex3].ToVector2(true));
+			(Vector2 v0, Vector2 v1, Vector2 v2) vertexUvs = (
+			    _wldMesh.TextureUvCoordinates[triangle.Vertex1].ToVector2(true),
+				_wldMesh.TextureUvCoordinates[triangle.Vertex2].ToVector2(true),
+				_wldMesh.TextureUvCoordinates[triangle.Vertex3].ToVector2(true));
 
             return vertexUvs;
-        }
+		}
 
         public (int v0, int v1, int v2) GetBoneIndexes(DataTypes.Polygon triangle, bool isSkinned, bool usesMobPieces, int singularBoneIndex)
         {
-            (int v0, int v1, int v2) boneIndexes = (singularBoneIndex, singularBoneIndex, singularBoneIndex);
-            if (isSkinned && (usesMobPieces || singularBoneIndex == -1))
-            {
-                var boneOffset = singularBoneIndex == -1 ? 0 : singularBoneIndex;
-                boneIndexes = (
-                    GetBoneIndexForVertex(triangle.Vertex1) + boneOffset,
-                    GetBoneIndexForVertex(triangle.Vertex2) + boneOffset,
-                    GetBoneIndexForVertex(triangle.Vertex3) + boneOffset);
-            }
+			(int v0, int v1, int v2) boneIndexes = (singularBoneIndex, singularBoneIndex, singularBoneIndex);
+			if (isSkinned && (usesMobPieces || singularBoneIndex == -1))
+			{
+				var boneOffset = singularBoneIndex == -1 ? 0 : singularBoneIndex;
+				boneIndexes = (
+				    GetBoneIndexForVertex(triangle.Vertex1) + boneOffset,
+				    GetBoneIndexForVertex(triangle.Vertex2) + boneOffset,
+					GetBoneIndexForVertex(triangle.Vertex3) + boneOffset);
+			}
 
             return boneIndexes;
-        }
+		}
 
-        public (Vector4? v0, Vector4? v1, Vector4? v2) GetVertexColorVectors(DataTypes.Polygon triangle, bool canExportVertexColors, ObjInstance objectInstance = null)
-        {
-            if (!canExportVertexColors) return (null, null, null);
+		public (Vector4? v0, Vector4? v1, Vector4? v2) GetVertexColorVectors(DataTypes.Polygon triangle, bool canExportVertexColors, ObjInstance objectInstance = null)
+		{
+			if (!canExportVertexColors) return (null, null, null);
 
-            var objInstanceColors = objectInstance?.Colors?.Colors ?? new List<WldColor>();
-            var meshColors = _wldMesh?.Colors ?? new List<WldColor>();
+			var objInstanceColors = objectInstance?.Colors?.Colors ?? new List<WldColor>();
+			var meshColors = _wldMesh?.Colors ?? new List<WldColor>();
 
-            var v0Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex1);
-            var v1Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex2);
-            var v2Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex3);
+			var v0Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex1);
+			var v1Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex2);
+			var v2Color = CoalesceVertexColor(meshColors, objInstanceColors, triangle.Vertex3);
 
-            return (v0Color, v1Color, v2Color);
-        }
+			return (v0Color, v1Color, v2Color);
+		}
 
         public void Reset()
         {
@@ -1235,75 +1235,75 @@ namespace LanternExtractor.EQ.Wld.Exporters
             _wldVertexIndexToDuplicatedVertexNormals.Clear();
         }
 
-        private (Vector3 v0, Vector3 v1, Vector3 v2) GetDuplicateVertexNormalsForTriangle(DataTypes.Polygon triangle)
+		private (Vector3 v0, Vector3 v1, Vector3 v2) GetDuplicateVertexNormalsForTriangle(DataTypes.Polygon triangle)
         {
             if (!_wldVertexIndexToDuplicatedVertexNormals.TryGetValue(triangle.Vertex1, out var v0Normal))
             {
                 v0Normal = Vector3.Normalize(-_wldMesh.Normals[triangle.Vertex1].ToVector3(true));
             }
-            if (!_wldVertexIndexToDuplicatedVertexNormals.TryGetValue(triangle.Vertex2, out var v1Normal))
-            {
-                v1Normal = Vector3.Normalize(-_wldMesh.Normals[triangle.Vertex2].ToVector3(true));
-            }
-            if (!_wldVertexIndexToDuplicatedVertexNormals.TryGetValue(triangle.Vertex3, out var v2Normal))
-            {
-                v2Normal = Vector3.Normalize(-_wldMesh.Normals[triangle.Vertex3].ToVector3(true));
-            }
+			if (!_wldVertexIndexToDuplicatedVertexNormals.TryGetValue(triangle.Vertex2, out var v1Normal))
+			{
+				v1Normal = Vector3.Normalize(-_wldMesh.Normals[triangle.Vertex2].ToVector3(true));
+			}
+			if (!_wldVertexIndexToDuplicatedVertexNormals.TryGetValue(triangle.Vertex3, out var v2Normal))
+			{
+				v2Normal = Vector3.Normalize(-_wldMesh.Normals[triangle.Vertex3].ToVector3(true));
+			}
 
             return (v0Normal, v1Normal, v2Normal);
-        }
+		}
 
-        private int GetBoneIndexForVertex(int vertexIndex)
-        {
-            foreach (var indexedMobVertexPiece in _wldMesh.MobPieces)
-            {
-                if (vertexIndex >= indexedMobVertexPiece.Value.Start &&
-                    vertexIndex < indexedMobVertexPiece.Value.Start + indexedMobVertexPiece.Value.Count)
-                {
-                    return indexedMobVertexPiece.Key;
-                }
-            }
-            return 0;
-        }
+		private int GetBoneIndexForVertex(int vertexIndex)
+		{
+			foreach (var indexedMobVertexPiece in _wldMesh.MobPieces)
+			{
+				if (vertexIndex >= indexedMobVertexPiece.Value.Start &&
+					vertexIndex < indexedMobVertexPiece.Value.Start + indexedMobVertexPiece.Value.Count)
+				{
+					return indexedMobVertexPiece.Key;
+				}
+			}
+			return 0;
+		}
 
-        private Vector4 CoalesceVertexColor(List<WldColor> meshColors, List<WldColor> objInstanceColors, int vertexIndex)
-        {
-            if (vertexIndex < objInstanceColors.Count)
-            {
-                return objInstanceColors[vertexIndex].ToVector4();
-            }
-            else if (vertexIndex < meshColors.Count)
-            {
-                return meshColors[vertexIndex].ToVector4();
-            }
-            else
-            {
-                return DefaultVertexColor;
-            }
-        }
-    }
+		private Vector4 CoalesceVertexColor(List<WldColor> meshColors, List<WldColor> objInstanceColors, int vertexIndex)
+		{
+			if (vertexIndex < objInstanceColors.Count)
+			{
+				return objInstanceColors[vertexIndex].ToVector4();
+			}
+			else if (vertexIndex < meshColors.Count)
+			{
+				return meshColors[vertexIndex].ToVector4();
+			}
+			else
+			{
+				return DefaultVertexColor;
+			}
+		}
+	}
 
-    public class TriangleVertexSetComparer : IEqualityComparer<DataTypes.Polygon>
-    {
-        public bool Equals(DataTypes.Polygon polyX, DataTypes.Polygon polyY)
-        {
-            var polyXSet = new HashSet<int>() { polyX.Vertex1, polyX.Vertex2, polyX.Vertex3 };
-            var polyYSet = new HashSet<int>() { polyY.Vertex1, polyY.Vertex2, polyY.Vertex3 };
+	public class TriangleVertexSetComparer : IEqualityComparer<DataTypes.Polygon>
+	{
+		public bool Equals(DataTypes.Polygon polyX, DataTypes.Polygon polyY)
+		{
+			var polyXSet = new HashSet<int>() { polyX.Vertex1, polyX.Vertex2, polyX.Vertex3 };
+			var polyYSet = new HashSet<int>() { polyY.Vertex1, polyY.Vertex2, polyY.Vertex3 };
 
             return polyXSet.SetEquals(polyYSet);
-        }
+		}
 
-        public int GetHashCode(DataTypes.Polygon poly)
-        {
+		public int GetHashCode(DataTypes.Polygon poly)
+		{
             var polyVertList1 = new List<int>() { poly.Vertex1, poly.Vertex2, poly.Vertex3 };
             polyVertList1.Sort();
 
-            unchecked
+			unchecked
             {
                 return 391 + polyVertList1.GetHashCode();
             }
-        }
-    }
+		}
+	}
 
     public struct UniqueLight
     {
@@ -1330,15 +1330,15 @@ namespace LanternExtractor.EQ.Wld.Exporters
         bool ShouldSkipMeshGenerationForMaterial(string materialName);
     }
 
-    static class ImageAlphaConverter
+	static class ImageAlphaConverter
     {
         public static string AddAlphaToImage(string filePath, ShaderType shaderType)
         {
             // var suffix = $"_{MaterialList.GetMaterialPrefix(shaderType).TrimEnd('_')}";
             var prefix = MaterialList.GetMaterialPrefix(shaderType);
-            // var newFileName = $"{Path.GetFileNameWithoutExtension(filePath)}{suffix}{Path.GetExtension(filePath)}";
-            var newFileName = $"{prefix}{Path.GetFileNameWithoutExtension(filePath)}{Path.GetExtension(filePath)}";
-            var newFilePath = Path.Combine(Path.GetDirectoryName(filePath), newFileName);
+			// var newFileName = $"{Path.GetFileNameWithoutExtension(filePath)}{suffix}{Path.GetExtension(filePath)}";
+			var newFileName = $"{prefix}{Path.GetFileNameWithoutExtension(filePath)}{Path.GetExtension(filePath)}";
+			var newFilePath = Path.Combine(Path.GetDirectoryName(filePath), newFileName);
 
             if (File.Exists(newFilePath)) return newFilePath;
 
@@ -1408,7 +1408,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
         public static Vector4 ToVector4(this Color color)
         {
-            return new Vector4(color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f);
+            return new Vector4(color.R/255.0f, color.G/255.0f, color.B/255.0f, color.A/255.0f);
         }
     }
 

--- a/LanternExtractor/EQ/Wld/Exporters/PlayerCharacterGltfExporter.cs
+++ b/LanternExtractor/EQ/Wld/Exporters/PlayerCharacterGltfExporter.cs
@@ -13,7 +13,7 @@ using static LanternExtractor.EQ.Wld.Exporters.GltfWriter;
 namespace LanternExtractor.EQ.Wld.Exporters
 {
     public static class PlayerCharacterGltfExporter
-    {
+    { 
         public static void ExportPlayerCharacter(PlayerCharacterModel pcEquipment, WldFileCharacters wldChrFile, WldFileEquipment wldEqFile,
             ILogger logger, Settings settings, string pcExportName)
         {
@@ -29,14 +29,14 @@ namespace LanternExtractor.EQ.Wld.Exporters
             var exportFormat = settings.ExportGltfInGlbFormat ? GltfExportFormat.Glb : GltfExportFormat.GlTF;
             var gltfWriter = new GltfWriter(settings, exportFormat, logger);
 
-            pcEquipment.FixHelmMaterial();
+			pcEquipment.FixHelmMaterial();
 
-            var exportFolder = Path.Combine(wldChrFile.RootExportFolder, pcExportName);
+			var exportFolder = Path.Combine(wldChrFile.RootExportFolder, pcExportName);
 
             AddMeshDataToGltfWriter(pcEquipment, gltfWriter, wldEqFile, skeleton,
                 exportFolder, logger, settings);
 
-            var exportFilePath = Path.Combine(exportFolder, $"{pcExportName}.gltf");
+			var exportFilePath = Path.Combine(exportFolder, $"{pcExportName}.gltf");
             gltfWriter.WriteAssetToFile(exportFilePath, false, skeleton.ModelBase, true);
 
             var jsonOutFilePath = Path.Combine(exportFolder, $"{pcExportName}_{DateTime.Now:yyyyMMddhhmmss}.json");
@@ -45,41 +45,41 @@ namespace LanternExtractor.EQ.Wld.Exporters
             File.WriteAllText(jsonOutFilePath, JsonSerializer.Serialize(pcEquipment, serializerOptions));
         }
 
-        public static void ExportPlayerCharacterVariationsForActor(string actorName,
+        public static void ExportPlayerCharacterVariationsForActor(string actorName, 
             IEnumerable<(string, PlayerCharacterModel)> pcVariations, WldFileCharacters wldChrFile,
             WldFileEquipment wldEqFile, string zoneName, ILogger logger, Settings settings)
         {
-            var lookupName = $"{actorName}_ACTORDEF";
+			var lookupName = $"{actorName}_ACTORDEF";
 
-            var actor = wldChrFile.GetFragmentByNameIncludingInjectedWlds<Actor>(lookupName);
+			var actor = wldChrFile.GetFragmentByNameIncludingInjectedWlds<Actor>(lookupName);
 
-            var skeleton = actor?.SkeletonReference?.SkeletonHierarchy;
+			var skeleton = actor?.SkeletonReference?.SkeletonHierarchy;
 
             if (skeleton == null) return;
 
             var savedGltfWriters = new Dictionary<PlayerCharacterModel, GltfWriter>(new CharacterVariationComparer());
             var exportFolder = Path.Combine(wldChrFile.RootExportFolder, zoneName, "Characters");
-            foreach (var pcVariation in pcVariations)
+			foreach (var pcVariation in pcVariations)
             {
                 var npcName = pcVariation.Item1;
                 var pcModel = pcVariation.Item2;
                 pcModel.FixHelmMaterial();
-                var exportFilePath = Path.Combine(exportFolder, $"{npcName}.gltf");
+				var exportFilePath = Path.Combine(exportFolder, $"{npcName}.gltf");
 
-                if (savedGltfWriters.TryGetValue(pcModel, out var gltfWriter))
+				if (savedGltfWriters.TryGetValue(pcModel, out var gltfWriter))
                 {
                     gltfWriter.WriteAssetToFile(exportFilePath, true);
                     continue;
                 }
-                var exportFormat = settings.ExportGltfInGlbFormat ? GltfExportFormat.Glb : GltfExportFormat.GlTF;
-                gltfWriter = new GltfWriter(settings, exportFormat, logger);
+				var exportFormat = settings.ExportGltfInGlbFormat ? GltfExportFormat.Glb : GltfExportFormat.GlTF;
+				gltfWriter = new GltfWriter(settings, exportFormat, logger);
 
-                AddMeshDataToGltfWriter(pcModel, gltfWriter, wldEqFile, skeleton,
-                    exportFolder, logger, settings);
+				AddMeshDataToGltfWriter(pcModel, gltfWriter, wldEqFile, skeleton,
+	                exportFolder, logger, settings);
 
                 gltfWriter.WriteAssetToFile(exportFilePath, true, skeleton.ModelBase);
                 savedGltfWriters.Add(pcModel, gltfWriter);
-            }
+			}
         }
 
         public static void AddPcEquipmentClientDataFromDatabase(PlayerCharacterModel pcCharacterModel)
@@ -127,85 +127,85 @@ namespace LanternExtractor.EQ.Wld.Exporters
             }
         }
 
-        private static void AddMeshDataToGltfWriter(PlayerCharacterModel pcEquipment, GltfWriter gltfWriter,
+        private static void AddMeshDataToGltfWriter(PlayerCharacterModel pcEquipment, GltfWriter gltfWriter, 
             WldFileEquipment wldEqFile, SkeletonHierarchy skeleton,
-            string exportFolder, ILogger logger, Settings settings)
+			string exportFolder, ILogger logger, Settings settings)
         {
             //var actorName = pcEquipment.RaceGender;
-            GetBodyAndHeadMeshes(pcEquipment, skeleton, out var bodyMesh, out var headMesh);
+			GetBodyAndHeadMeshes(pcEquipment, skeleton, out var bodyMesh, out var headMesh);
 
-            WldFragment primaryMeshOrSkeleton = null;
-            WldFragment secondaryMeshOrSkeleton = null;
-            WldFragment veliousHelm = null;
-            var veliousHelmModelId = pcEquipment.Head.Velious ? PlayerCharacterModel.RaceGenderToVeliousHelmModel[pcEquipment.RaceGender] : null;
+			WldFragment primaryMeshOrSkeleton = null;
+			WldFragment secondaryMeshOrSkeleton = null;
+			WldFragment veliousHelm = null;
+			var veliousHelmModelId = pcEquipment.Head.Velious ? PlayerCharacterModel.RaceGenderToVeliousHelmModel[pcEquipment.RaceGender] : null;
 
-            var wldFragmentsWithMaterialLists = new List<WldFragment>() { bodyMesh, headMesh };
-            if (wldEqFile != null)
-            {
-                primaryMeshOrSkeleton = GltfCharacterHeldEquipmentHelper.GetMeshOrSkeletonForCharacterHeldEquipment
-                    (pcEquipment.Primary_ID, wldEqFile, logger);
-                wldFragmentsWithMaterialLists.Add(primaryMeshOrSkeleton);
-                secondaryMeshOrSkeleton = GltfCharacterHeldEquipmentHelper.GetMeshOrSkeletonForCharacterHeldEquipment
-                    (pcEquipment.Secondary_ID, wldEqFile, logger);
-                wldFragmentsWithMaterialLists.Add(secondaryMeshOrSkeleton);
-                veliousHelm = GltfCharacterHeldEquipmentHelper.GetMeshOrSkeletonForCharacterHeldEquipment
-                    (veliousHelmModelId, wldEqFile, logger);
-                wldFragmentsWithMaterialLists.Add(veliousHelm);
-            }
+			var wldFragmentsWithMaterialLists = new List<WldFragment>() { bodyMesh, headMesh };
+			if (wldEqFile != null)
+			{
+				primaryMeshOrSkeleton = GltfCharacterHeldEquipmentHelper.GetMeshOrSkeletonForCharacterHeldEquipment
+					(pcEquipment.Primary_ID, wldEqFile, logger);
+				wldFragmentsWithMaterialLists.Add(primaryMeshOrSkeleton);
+				secondaryMeshOrSkeleton = GltfCharacterHeldEquipmentHelper.GetMeshOrSkeletonForCharacterHeldEquipment
+					(pcEquipment.Secondary_ID, wldEqFile, logger);
+				wldFragmentsWithMaterialLists.Add(secondaryMeshOrSkeleton);
+				veliousHelm = GltfCharacterHeldEquipmentHelper.GetMeshOrSkeletonForCharacterHeldEquipment
+					(veliousHelmModelId, wldEqFile, logger);
+				wldFragmentsWithMaterialLists.Add(veliousHelm);
+			}
 
-            var materialLists = ActorGltfExporter.GatherMaterialLists(wldFragmentsWithMaterialLists.Where(m => m != null).ToList());
+			var materialLists = ActorGltfExporter.GatherMaterialLists(wldFragmentsWithMaterialLists.Where(m => m != null).ToList());
 
-            gltfWriter.GenerateGltfMaterials(materialLists, Path.Combine(exportFolder, "Textures"), true);
+			gltfWriter.GenerateGltfMaterials(materialLists, Path.Combine(exportFolder, "Textures"), true);
 
-            var originalVertices = MeshExportHelper.ShiftMeshVertices(bodyMesh, skeleton, true, "pos", 0);
-            gltfWriter.AddFragmentData(bodyMesh, skeleton, -1, pcEquipment);
+			var originalVertices = MeshExportHelper.ShiftMeshVertices(bodyMesh, skeleton, true, "pos", 0);
+			gltfWriter.AddFragmentData(bodyMesh, skeleton, -1, pcEquipment);
             bodyMesh.Vertices = originalVertices;
-            originalVertices = MeshExportHelper.ShiftMeshVertices(headMesh, skeleton, true, "pos", 0);
-            gltfWriter.AddFragmentData(headMesh, skeleton, -1, pcEquipment);
+			originalVertices = MeshExportHelper.ShiftMeshVertices(headMesh, skeleton, true, "pos", 0);
+			gltfWriter.AddFragmentData(headMesh, skeleton, -1, pcEquipment);
             headMesh.Vertices = originalVertices;
 
-            var boneIndexOffset = skeleton.Skeleton.Count;
+			var boneIndexOffset = skeleton.Skeleton.Count;
 
-            GltfCharacterHeldEquipmentHelper.AddCharacterHeldEquipmentToGltfWriter
-                (primaryMeshOrSkeleton, pcEquipment.Primary_ID, skeleton, "r_point", gltfWriter, ref boneIndexOffset);
-            var secondaryAttachBone = GltfCharacterHeldEquipmentHelper.IsShield(pcEquipment.Secondary_ID) ? "shield_point" : "l_point";
-            GltfCharacterHeldEquipmentHelper.AddCharacterHeldEquipmentToGltfWriter
-                (secondaryMeshOrSkeleton, pcEquipment.Secondary_ID, skeleton, secondaryAttachBone, gltfWriter, ref boneIndexOffset);
-            GltfCharacterHeldEquipmentHelper.AddCharacterHeldEquipmentToGltfWriter
-                (veliousHelm, veliousHelmModelId, skeleton, "he", gltfWriter, ref boneIndexOffset, pcEquipment.GetVeliousHelmCharacter());
+			GltfCharacterHeldEquipmentHelper.AddCharacterHeldEquipmentToGltfWriter
+				(primaryMeshOrSkeleton, pcEquipment.Primary_ID, skeleton, "r_point", gltfWriter, ref boneIndexOffset);
+			var secondaryAttachBone = GltfCharacterHeldEquipmentHelper.IsShield(pcEquipment.Secondary_ID) ? "shield_point" : "l_point";
+			GltfCharacterHeldEquipmentHelper.AddCharacterHeldEquipmentToGltfWriter
+				(secondaryMeshOrSkeleton, pcEquipment.Secondary_ID, skeleton, secondaryAttachBone, gltfWriter, ref boneIndexOffset);
+			GltfCharacterHeldEquipmentHelper.AddCharacterHeldEquipmentToGltfWriter
+				(veliousHelm, veliousHelmModelId, skeleton, "he", gltfWriter, ref boneIndexOffset, pcEquipment.GetVeliousHelmCharacter());
 
-            gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", true, true);
+			gltfWriter.ApplyAnimationToSkeleton(skeleton, "pos", true, true);
 
-            if (settings.ExportAllAnimationFrames)
-            {
-                foreach (var animationKey in skeleton.Animations.Keys
-                    .Where(a => settings.ExportedAnimationTypes.Contains(a.Substring(0, 1).ToLower()))
-                    .OrderBy(k => k, new AnimationKeyComparer()))
-                {
-                    gltfWriter.ApplyAnimationToSkeleton(skeleton, animationKey, true, false);
-                }
-            }
-        }
+			if (settings.ExportAllAnimationFrames)
+			{
+				foreach (var animationKey in skeleton.Animations.Keys
+					.Where(a => settings.ExportedAnimationTypes.Contains(a.Substring(0, 1).ToLower()))
+					.OrderBy(k => k, new AnimationKeyComparer()))
+				{
+					gltfWriter.ApplyAnimationToSkeleton(skeleton, animationKey, true, false);
+				}
+			}
+		}
 
-        private static void GetBodyAndHeadMeshes(PlayerCharacterModel pcEquipment, SkeletonHierarchy skeleton,
-            out Mesh bodyMesh, out Mesh headMesh)
-        {
-            var actorName = pcEquipment.RaceGender;
-            var allMeshes = skeleton.Meshes.Union(skeleton.SecondaryMeshes);
-            var bodyMeshName = pcEquipment.IsChestRobe() ? $"{actorName}01" : actorName;
-            bodyMeshName = $"{bodyMeshName}_DMSPRITEDEF";
+		private static void GetBodyAndHeadMeshes(PlayerCharacterModel pcEquipment, SkeletonHierarchy skeleton,
+			out Mesh bodyMesh, out Mesh headMesh)
+		{
+			var actorName = pcEquipment.RaceGender;
+			var allMeshes = skeleton.Meshes.Union(skeleton.SecondaryMeshes);
+			var bodyMeshName = pcEquipment.IsChestRobe() ? $"{actorName}01" : actorName;
+			bodyMeshName = $"{bodyMeshName}_DMSPRITEDEF";
 
-            var headMeshName = $"{actorName}HE{pcEquipment.Head.Material:00}";
-            headMeshName = $"{headMeshName}_DMSPRITEDEF";
-            bodyMesh = allMeshes.Where(m => m.Name.Equals(bodyMeshName, StringComparison.InvariantCultureIgnoreCase)).Single();
-            headMesh = allMeshes.Where(m => m.Name.Equals(headMeshName, StringComparison.InvariantCultureIgnoreCase)).Single();
-        }
+			var headMeshName = $"{actorName}HE{pcEquipment.Head.Material:00}";
+			headMeshName = $"{headMeshName}_DMSPRITEDEF";
+			bodyMesh = allMeshes.Where(m => m.Name.Equals(bodyMeshName, StringComparison.InvariantCultureIgnoreCase)).Single();
+			headMesh = allMeshes.Where(m => m.Name.Equals(headMeshName, StringComparison.InvariantCultureIgnoreCase)).Single();
+		}
 
-        private static readonly string VeliousHelmIdFile = "IT240";
+		private static readonly string VeliousHelmIdFile = "IT240";
     }
 
     public class PlayerCharacterModel : ICharacterModel
-    {
+	{
         public int Face { get; set; }
         public string RaceGender { get; set; }
         [JsonPropertyName("Primary ID")]
@@ -245,7 +245,7 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
             if (variationIndex == 0) return false;
 
-            variationIndex = isChest && IsChestRobe() ? variationIndex - 7 : variationIndex - 1;
+			variationIndex = isChest && IsChestRobe() ? variationIndex - 7 : variationIndex - 1;
 
             return true;
         }
@@ -278,29 +278,29 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
         public void FixHelmMaterial()
         {
-            if (Head.Material == 7)
-            {
-                Head.Material = 2; // Kunark chain
-            }
-            else if (RequiresMeshModificationsForVeliousHelm() && RaceGender != "ERM")
-            {
-                Head.Material = 3;
-            }
-            else if (Head.Material == 4 || Head.Material > 16 || Head.Velious) // Monk or Velious
-            {
-                Head.Material = 0;
-            }
-        }
+			if (Head.Material == 7)
+			{
+				Head.Material = 2; // Kunark chain
+			}
+			else if (RequiresMeshModificationsForVeliousHelm() && RaceGender != "ERM")
+			{
+				Head.Material = 3;
+			}
+			else if (Head.Material == 4 || Head.Material > 16 || Head.Velious) // Monk or Velious
+			{
+				Head.Material = 0;
+			}
+		}
 
         public ICharacterModel GetVeliousHelmCharacter()
         {
             return new VeliousHelmCharacter(Head.Color);
         }
 
-        private Equipment GetEquipmentForImageName(string imageName, out bool isChest)
-        {
-            isChest = false;
-            imageName = imageName.ToLower();
+		private Equipment GetEquipmentForImageName(string imageName, out bool isChest)
+		{
+			isChest = false;
+			imageName = imageName.ToLower();
             if (imageName.StartsWith("clk"))
             {
                 isChest = true;
@@ -382,8 +382,8 @@ namespace LanternExtractor.EQ.Wld.Exporters
         };
 
         public static readonly HashSet<string> RaceGendersRequiringMeshModificationsWearingVeliousHelm = new HashSet<string>()
-        {
-            "BAF", "DAF", "ELF", "ERF", "ERM", "HUF"
+        { 
+            "BAF", "DAF", "ELF", "ERF", "ERM", "HUF" 
         };
 
         public static readonly IDictionary<string, string> RaceGenderToVeliousHelmModel = new Dictionary<string, string>()
@@ -434,18 +434,18 @@ namespace LanternExtractor.EQ.Wld.Exporters
 
         public bool ShouldSkipMeshGenerationForMaterial(string materialName) => false;
 
-        public bool TryGetMaterialVariation(string imageName, out int variationIndex, out DColor? color)
-        {
+		public bool TryGetMaterialVariation(string imageName, out int variationIndex, out DColor? color)
+		{
             variationIndex = 0;
             color = _color;
             return false;
-        }
-    }
+		}
+	}
 
-    public class CharacterVariationComparer : IEqualityComparer<PlayerCharacterModel>
-    {
-        public bool Equals(PlayerCharacterModel x, PlayerCharacterModel y)
-        {
+	public class CharacterVariationComparer : IEqualityComparer<PlayerCharacterModel>
+	{
+		public bool Equals(PlayerCharacterModel x, PlayerCharacterModel y)
+		{
             return string.Equals(x.RaceGender, y.RaceGender, StringComparison.InvariantCultureIgnoreCase) &&
                 string.Equals(x.Primary_ID, y.Primary_ID, StringComparison.InvariantCultureIgnoreCase) &&
                 string.Equals(x.Secondary_ID, y.Secondary_ID, StringComparison.InvariantCultureIgnoreCase) &&
@@ -459,10 +459,10 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 x.Chest.Color == y.Chest.Color &&
                 x.Legs.Material == y.Legs.Material &&
                 x.Feet.Material == y.Feet.Material;
-        }
+		}
 
-        public int GetHashCode(PlayerCharacterModel obj)
-        {
+		public int GetHashCode(PlayerCharacterModel obj)
+		{
             return (obj.RaceGender.ToUpper(),
                 obj.Primary_ID?.ToUpper(),
                 obj.Secondary_ID?.ToUpper(),
@@ -476,9 +476,9 @@ namespace LanternExtractor.EQ.Wld.Exporters
                 obj.Chest.Color,
                 obj.Legs.Material,
                 obj.Feet.Material).GetHashCode();
-        }
-    }
-    public class ColorJsonConverter : JsonConverter<DColor?>
+		}
+	}
+	public class ColorJsonConverter : JsonConverter<DColor?>
     {
         public override DColor? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/LanternExtractor/Settings.cs
+++ b/LanternExtractor/Settings.cs
@@ -94,30 +94,30 @@ namespace LanternExtractor
         /// </summary>
         public bool ExportZoneCharacterVariations { get; private set; }
 
-        /// <summary>
-        /// Exports zone glTF with light instances with intensity set to the
+		/// <summary>
+		/// Exports zone glTF with light instances with intensity set to the
         /// provided value. If set at 0, lights are not exported
-        /// </summary>
-        public float LightIntensityMultiplier { get; private set; }
+		/// </summary>
+		public float LightIntensityMultiplier { get; private set; }
         public bool ExportZoneWithLights => LightIntensityMultiplier > 0;
 
-        /// <summary>
-        /// Exports zone with objects with skeletal animations included
-        /// </summary>
-        public bool ExportZoneObjectsWithSkeletalAnimations { get; private set; }
+		/// <summary>
+		/// Exports zone with objects with skeletal animations included
+		/// </summary>
+		public bool ExportZoneObjectsWithSkeletalAnimations { get; private set; }
 
         /// <summary>
 		/// Sets the export scale of the zone when exported
 		/// </summary>
         public float ExportZoneScale { get; private set; }
 
-        /// <summary>
-        /// Export vertex colors with glTF model. Default behavior of glTF renderers
-        /// is to mix the vertex color with the base color, which will not look right.
-        /// Only turn this on if you intend to do some post-processing that
-        /// requires vertex colors being present.
-        /// </summary>
-        public bool ExportGltfVertexColors { get; private set; }
+		/// <summary>
+		/// Export vertex colors with glTF model. Default behavior of glTF renderers
+		/// is to mix the vertex color with the base color, which will not look right.
+		/// Only turn this on if you intend to do some post-processing that
+		/// requires vertex colors being present.
+		/// </summary>
+		public bool ExportGltfVertexColors { get; private set; }
 
         /// <summary>
         /// Exports glTF models in .GLB file format. GLB packages the .glTF json, the
@@ -127,10 +127,10 @@ namespace LanternExtractor
         /// </summary>
         public bool ExportGltfInGlbFormat { get; private set; }
 
-        /// <summary>
-        /// Generate duplicate sets of vertices for triangles sharing vertices with another
-        /// </summary>
-        public bool SeparateTwoFacedTriangles { get; private set; }
+		/// <summary>
+		/// Generate duplicate sets of vertices for triangles sharing vertices with another
+		/// </summary>
+		public bool SeparateTwoFacedTriangles { get; private set; }
 
         /// <summary>
         /// Additional files that should be copied when extracting with `all` or `clientdata`
@@ -225,27 +225,27 @@ namespace LanternExtractor
                 ExportZoneWithDoors = Convert.ToBoolean(parsedSettings["ExportZoneWithDoors"]);
             }
 
-            if (parsedSettings.ContainsKey("ExportZoneCharacterVariations"))
-            {
-                ExportZoneCharacterVariations = Convert.ToBoolean(parsedSettings["ExportZoneCharacterVariations"]);
-            }
+			if (parsedSettings.ContainsKey("ExportZoneCharacterVariations"))
+			{
+				ExportZoneCharacterVariations = Convert.ToBoolean(parsedSettings["ExportZoneCharacterVariations"]);
+			}
 
-            if (parsedSettings.ContainsKey("LightIntensityMultiplier"))
-            {
-                LightIntensityMultiplier = Convert.ToSingle(parsedSettings["LightIntensityMultiplier"]);
-            }
+			if (parsedSettings.ContainsKey("LightIntensityMultiplier"))
+			{
+				LightIntensityMultiplier = Convert.ToSingle(parsedSettings["LightIntensityMultiplier"]);
+			}
 
-            if (parsedSettings.ContainsKey("ExportZoneObjectsWithSkeletalAnimations"))
-            {
-                ExportZoneObjectsWithSkeletalAnimations = Convert.ToBoolean(parsedSettings["ExportZoneObjectsWithSkeletalAnimations"]);
-            }
+			if (parsedSettings.ContainsKey("ExportZoneObjectsWithSkeletalAnimations"))
+			{
+				ExportZoneObjectsWithSkeletalAnimations = Convert.ToBoolean(parsedSettings["ExportZoneObjectsWithSkeletalAnimations"]);
+			}
 
             if (parsedSettings.ContainsKey("ExportZoneScale"))
             {
                 ExportZoneScale = Convert.ToSingle(parsedSettings["ExportZoneScale"]);
             }
 
-            if (parsedSettings.ContainsKey("ModelExportFormat"))
+			if (parsedSettings.ContainsKey("ModelExportFormat"))
             {
                 var exportFormatSetting = (ModelExportFormat)Convert.ToInt32(parsedSettings["ModelExportFormat"]);
                 ModelExportFormat = exportFormatSetting;
@@ -281,19 +281,19 @@ namespace LanternExtractor
                 ExportGltfInGlbFormat = Convert.ToBoolean(parsedSettings["ExportGltfInGlbFormat"]);
             }
 
-            if (parsedSettings.ContainsKey("SeparateTwoFacedTriangles"))
-            {
-                SeparateTwoFacedTriangles = Convert.ToBoolean(parsedSettings["SeparateTwoFacedTriangles"]);
-            }
+			if (parsedSettings.ContainsKey("SeparateTwoFacedTriangles"))
+			{
+				SeparateTwoFacedTriangles = Convert.ToBoolean(parsedSettings["SeparateTwoFacedTriangles"]);
+			}
 
-            if (parsedSettings.ContainsKey("ExportedAnimationTypes"))
+			if (parsedSettings.ContainsKey("ExportedAnimationTypes"))
             {
                 var animationIncludeString = parsedSettings["ExportedAnimationTypes"].Trim();
-                ExportedAnimationTypes = animationIncludeString
+				ExportedAnimationTypes = animationIncludeString
                     .Split(',').Select(a => a.Trim().ToLower())
                     .Where(a => a.Length == 1).ToList();
             }
-
+			
             if (parsedSettings.ContainsKey("ClientDataToCopy"))
             {
                 ClientDataToCopy = parsedSettings["ClientDataToCopy"];
@@ -311,10 +311,10 @@ namespace LanternExtractor
         }
 
         public bool UsingCombinedGlobalChr()
-        {
+		{
             return ModelExportFormat != ModelExportFormat.Intermediate &&
-                (ExportAllAnimationFrames || ExportZoneCharacterVariations)
+				(ExportAllAnimationFrames || ExportZoneCharacterVariations)
                 && !RawS3dExtract;
-        }
+		}
     }
 }

--- a/LanternExtractor/Settings.cs
+++ b/LanternExtractor/Settings.cs
@@ -94,25 +94,30 @@ namespace LanternExtractor
         /// </summary>
         public bool ExportZoneCharacterVariations { get; private set; }
 
-		/// <summary>
-		/// Exports zone glTF with light instances with intensity set to the
+        /// <summary>
+        /// Exports zone glTF with light instances with intensity set to the
         /// provided value. If set at 0, lights are not exported
-		/// </summary>
-		public float LightIntensityMultiplier { get; private set; }
+        /// </summary>
+        public float LightIntensityMultiplier { get; private set; }
         public bool ExportZoneWithLights => LightIntensityMultiplier > 0;
 
-		/// <summary>
-		/// Exports zone with objects with skeletal animations included
-		/// </summary>
-		public bool ExportZoneObjectsWithSkeletalAnimations { get; private set; }
+        /// <summary>
+        /// Exports zone with objects with skeletal animations included
+        /// </summary>
+        public bool ExportZoneObjectsWithSkeletalAnimations { get; private set; }
 
-		/// <summary>
-		/// Export vertex colors with glTF model. Default behavior of glTF renderers
-		/// is to mix the vertex color with the base color, which will not look right.
-		/// Only turn this on if you intend to do some post-processing that
-		/// requires vertex colors being present.
+        /// <summary>
+		/// Sets the export scale of the zone when exported
 		/// </summary>
-		public bool ExportGltfVertexColors { get; private set; }
+        public float ExportZoneScale { get; private set; }
+
+        /// <summary>
+        /// Export vertex colors with glTF model. Default behavior of glTF renderers
+        /// is to mix the vertex color with the base color, which will not look right.
+        /// Only turn this on if you intend to do some post-processing that
+        /// requires vertex colors being present.
+        /// </summary>
+        public bool ExportGltfVertexColors { get; private set; }
 
         /// <summary>
         /// Exports glTF models in .GLB file format. GLB packages the .glTF json, the
@@ -122,10 +127,10 @@ namespace LanternExtractor
         /// </summary>
         public bool ExportGltfInGlbFormat { get; private set; }
 
-		/// <summary>
-		/// Generate duplicate sets of vertices for triangles sharing vertices with another
-		/// </summary>
-		public bool SeparateTwoFacedTriangles { get; private set; }
+        /// <summary>
+        /// Generate duplicate sets of vertices for triangles sharing vertices with another
+        /// </summary>
+        public bool SeparateTwoFacedTriangles { get; private set; }
 
         /// <summary>
         /// Additional files that should be copied when extracting with `all` or `clientdata`
@@ -220,22 +225,27 @@ namespace LanternExtractor
                 ExportZoneWithDoors = Convert.ToBoolean(parsedSettings["ExportZoneWithDoors"]);
             }
 
-			if (parsedSettings.ContainsKey("ExportZoneCharacterVariations"))
-			{
-				ExportZoneCharacterVariations = Convert.ToBoolean(parsedSettings["ExportZoneCharacterVariations"]);
-			}
+            if (parsedSettings.ContainsKey("ExportZoneCharacterVariations"))
+            {
+                ExportZoneCharacterVariations = Convert.ToBoolean(parsedSettings["ExportZoneCharacterVariations"]);
+            }
 
-			if (parsedSettings.ContainsKey("LightIntensityMultiplier"))
-			{
-				LightIntensityMultiplier = Convert.ToSingle(parsedSettings["LightIntensityMultiplier"]);
-			}
+            if (parsedSettings.ContainsKey("LightIntensityMultiplier"))
+            {
+                LightIntensityMultiplier = Convert.ToSingle(parsedSettings["LightIntensityMultiplier"]);
+            }
 
-			if (parsedSettings.ContainsKey("ExportZoneObjectsWithSkeletalAnimations"))
-			{
-				ExportZoneObjectsWithSkeletalAnimations = Convert.ToBoolean(parsedSettings["ExportZoneObjectsWithSkeletalAnimations"]);
-			}
+            if (parsedSettings.ContainsKey("ExportZoneObjectsWithSkeletalAnimations"))
+            {
+                ExportZoneObjectsWithSkeletalAnimations = Convert.ToBoolean(parsedSettings["ExportZoneObjectsWithSkeletalAnimations"]);
+            }
 
-			if (parsedSettings.ContainsKey("ModelExportFormat"))
+            if (parsedSettings.ContainsKey("ExportZoneScale"))
+            {
+                ExportZoneScale = Convert.ToSingle(parsedSettings["ExportZoneScale"]);
+            }
+
+            if (parsedSettings.ContainsKey("ModelExportFormat"))
             {
                 var exportFormatSetting = (ModelExportFormat)Convert.ToInt32(parsedSettings["ModelExportFormat"]);
                 ModelExportFormat = exportFormatSetting;
@@ -271,19 +281,19 @@ namespace LanternExtractor
                 ExportGltfInGlbFormat = Convert.ToBoolean(parsedSettings["ExportGltfInGlbFormat"]);
             }
 
-			if (parsedSettings.ContainsKey("SeparateTwoFacedTriangles"))
-			{
-				SeparateTwoFacedTriangles = Convert.ToBoolean(parsedSettings["SeparateTwoFacedTriangles"]);
-			}
+            if (parsedSettings.ContainsKey("SeparateTwoFacedTriangles"))
+            {
+                SeparateTwoFacedTriangles = Convert.ToBoolean(parsedSettings["SeparateTwoFacedTriangles"]);
+            }
 
-			if (parsedSettings.ContainsKey("ExportedAnimationTypes"))
+            if (parsedSettings.ContainsKey("ExportedAnimationTypes"))
             {
                 var animationIncludeString = parsedSettings["ExportedAnimationTypes"].Trim();
-				ExportedAnimationTypes = animationIncludeString
+                ExportedAnimationTypes = animationIncludeString
                     .Split(',').Select(a => a.Trim().ToLower())
                     .Where(a => a.Length == 1).ToList();
             }
-			
+
             if (parsedSettings.ContainsKey("ClientDataToCopy"))
             {
                 ClientDataToCopy = parsedSettings["ClientDataToCopy"];
@@ -301,10 +311,10 @@ namespace LanternExtractor
         }
 
         public bool UsingCombinedGlobalChr()
-		{
+        {
             return ModelExportFormat != ModelExportFormat.Intermediate &&
-				(ExportAllAnimationFrames || ExportZoneCharacterVariations)
+                (ExportAllAnimationFrames || ExportZoneCharacterVariations)
                 && !RawS3dExtract;
-		}
+        }
     }
 }

--- a/LanternExtractor/settings.txt
+++ b/LanternExtractor/settings.txt
@@ -88,6 +88,10 @@ LightIntensityMultiplier = 0.0
 # (glTF)
 ExportZoneObjectsWithSkeletalAnimations = false
 
+# Scale for exporting zone for glTF export
+# (glTF)
+ExportZoneScale = 0.2
+
 # Export vertex colors
 # Default behavior of glTF renderers is to mix the vertex color with the base color,
 # which will not look right. Only turn this on if you intend to do some post-processing that


### PR DESCRIPTION
Doing the transform at the mesh level when constructing a polygon ensures the correct polygon direction. We only need to flip when in a zone so needed to modify some params in methods that were being reused.

Also add a setting for zone scale export. For hooking data up to eqemu server data the exported scale of 1.0 is what lines up correctly with the data.

Lots of whitespace diffs here, I was making changes in visual studio this time and my clang format decided to be overzealous. If this is too much to sift through I can remake this branch without the formatting changes.